### PR TITLE
Use mosaic endpoints for all the residents APIs

### DIFF
--- a/utils/server/residents.js
+++ b/utils/server/residents.js
@@ -12,8 +12,10 @@ const headersWithKey = {
 };
 
 export const getResidents = async (params) => {
-  const { data } = await axios.get(`${ENDPOINT_API}/residents`, {
-    headers: headersWithKey,
+  const { data } = await axios.get(`${ENDPOINT_MOSAIC}/residents`, {
+    headers: {
+      Authorization: AWS_AUTHORIZATION,
+    },
     params,
   });
   return data.residents;

--- a/utils/server/residents.spec.js
+++ b/utils/server/residents.spec.js
@@ -19,9 +19,11 @@ describe('residents APIs', () => {
         foo: 'bar',
       });
       expect(axios.get).toHaveBeenCalled();
-      expect(axios.get.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/residents`);
+      expect(axios.get.mock.calls[0][0]).toEqual(
+        `${ENDPOINT_MOSAIC}/residents`
+      );
       expect(axios.get.mock.calls[0][1].headers).toEqual({
-        'x-api-key': AWS_KEY,
+        Authorization: AWS_AUTHORIZATION,
       });
       expect(data).toEqual('bar');
     });


### PR DESCRIPTION
**What**  
Now also the `getResidents` APIs are using the mosaic endpoint.