### PR TITLE
aligned cases APIs to the server

### DIFF
--- a/utils/server/residents.js
+++ b/utils/server/residents.js
@@ -31,7 +31,7 @@ export const getResident = async (id) => {
 };
 
 export const getResidentCases = async (mosaic_id) => {
-  const { data } = await axios.get(`${ENDPOINT_API}/residents/cases`, {
+  const { data } = await axios.get(`${ENDPOINT_API}/cases`, {
     headers: headersWithKey,
     params: { mosaic_id },
   });

--- a/utils/server/residents.spec.js
+++ b/utils/server/residents.spec.js
@@ -49,9 +49,7 @@ describe('residents APIs', () => {
       axios.get.mockResolvedValue({ data: { foo: 123, cases: 'bar' } });
       const data = await residentsAPI.getResidentCases(123);
       expect(axios.get).toHaveBeenCalled();
-      expect(axios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/residents/cases`
-      );
+      expect(axios.get.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/cases`);
       expect(axios.get.mock.calls[0][1].headers).toEqual({
         'x-api-key': AWS_KEY,
       });


### PR DESCRIPTION
**What**  
**cases** APIs moved from `/residents/cases` to `/cases` 🤷 