### PR TITLE
fixed changes from summary on conditional step

### DIFF
--- a/components/FormWizard/FormWizard.jsx
+++ b/components/FormWizard/FormWizard.jsx
@@ -6,7 +6,7 @@ import { useBeforeunload } from 'react-beforeunload';
 
 import DynamicStep from 'components/DynamicStep/DynamicStep';
 import Breadcrumbs from 'components/Breadcrumbs/Breadcrumbs';
-import { createSteps, getNextStepPath } from 'utils/steps';
+import { createSteps, getNextStepPath, haveStepsChanged } from 'utils/steps';
 import { getData, saveData } from 'utils/saveData';
 
 const FormWizard = ({
@@ -75,7 +75,7 @@ const FormWizard = ({
             const updatedData = { ...formData, ...data };
             setFormData(updatedData);
             step.onStepSubmit && step.onStepSubmit(updatedData);
-            fromSummary
+            fromSummary && !haveStepsChanged(formSteps, formData, updatedData)
               ? Router.push(stepPath, `${formPath}summary`)
               : Router.push(
                   stepPath,

--- a/utils/steps.jsx
+++ b/utils/steps.jsx
@@ -24,17 +24,30 @@ export const getNextStepPath = (
 export const renderOnCondition = (step, data, component) =>
   step.conditionalRender && !step.conditionalRender(data) ? null : component;
 
+export const filterConditionalSteps = (steps, data) =>
+  steps.filter(
+    (step) => step.conditionalRender && !step.conditionalRender(data)
+  );
+
 export const filterDataOnCondition = (steps, data) => {
-  const toFilterOut = steps
-    .filter((step) => step.conditionalRender && !step.conditionalRender(data))
-    .reduce(
-      (acc, step) => [
-        ...acc,
-        ...step.components.map((component) => component.name),
-      ],
-      []
-    );
+  const toFilterOut = filterConditionalSteps(steps, data).reduce(
+    (acc, step) => [
+      ...acc,
+      ...step.components.map((component) => component.name),
+    ],
+    []
+  );
   return Object.fromEntries(
     Object.entries(data).filter(([key]) => !toFilterOut.includes(key))
   );
+};
+
+export const haveStepsChanged = (steps, beforeData, afterData) => {
+  const stepsBefore = filterConditionalSteps(steps, beforeData).map(
+    (step) => step.id
+  );
+  const stepsAfter = filterConditionalSteps(steps, afterData).map(
+    (step) => step.id
+  );
+  return JSON.stringify(stepsBefore) !== JSON.stringify(stepsAfter);
 };

--- a/utils/steps.spec.jsx
+++ b/utils/steps.spec.jsx
@@ -2,7 +2,9 @@ import {
   createSteps,
   getNextStepPath,
   renderOnCondition,
+  filterConditionalSteps,
   filterDataOnCondition,
+  haveStepsChanged,
 } from './steps';
 
 import Summary from 'components/Steps/Summary';
@@ -61,6 +63,71 @@ describe('FormWizard', () => {
     });
   });
 
+  describe('filterConditionalSteps', () => {
+    const steps = [
+      {
+        id: 'step-a',
+        title: 'Step A',
+        components: [
+          {
+            component: 'Radios',
+            name: 'conditional_trigger',
+            label: 'Show next step?',
+            rules: { required: true },
+          },
+        ],
+      },
+      {
+        id: 'step-b',
+        title: 'Step B',
+        conditionalRender: ({ conditional_trigger }) =>
+          conditional_trigger === 'Yes',
+        components: [
+          {
+            component: 'TextInput',
+            name: 'foo',
+            rules: { required: true },
+          },
+        ],
+      },
+      {
+        id: 'step-c',
+        title: 'Step C',
+        conditionalRender: ({ conditional_trigger }) =>
+          conditional_trigger === 'No',
+        components: [
+          {
+            component: 'TextInput',
+            name: 'bar',
+            rules: { required: true },
+          },
+        ],
+      },
+    ];
+    const data = {
+      conditional_trigger: 'No',
+      bar: 'asd',
+      foo: 'asd',
+    };
+    expect(JSON.stringify(filterConditionalSteps(steps, data))).toEqual(
+      JSON.stringify([
+        {
+          id: 'step-b',
+          title: 'Step B',
+          conditionalRender: ({ conditional_trigger }) =>
+            conditional_trigger === 'Yes',
+          components: [
+            {
+              component: 'TextInput',
+              name: 'foo',
+              rules: { required: true },
+            },
+          ],
+        },
+      ])
+    );
+  });
+
   describe('filterDataOnCondition', () => {
     const steps = [
       {
@@ -109,5 +176,67 @@ describe('FormWizard', () => {
       conditional_trigger: 'No',
       bar: 'asd',
     });
+  });
+
+  describe('haveStepsChanged', () => {
+    const steps = [
+      {
+        id: 'step-a',
+        title: 'Step A',
+        components: [
+          {
+            component: 'Radios',
+            name: 'conditional_trigger',
+            label: 'Show next step?',
+            rules: { required: true },
+          },
+        ],
+      },
+      {
+        id: 'step-b',
+        title: 'Step B',
+        conditionalRender: ({ conditional_trigger }) =>
+          conditional_trigger === 'Yes',
+        components: [
+          {
+            component: 'TextInput',
+            name: 'foo',
+            rules: { required: true },
+          },
+        ],
+      },
+      {
+        id: 'step-c',
+        title: 'Step C',
+        conditionalRender: ({ conditional_trigger }) =>
+          conditional_trigger === 'No',
+        components: [
+          {
+            component: 'TextInput',
+            name: 'bar',
+            rules: { required: true },
+          },
+        ],
+      },
+    ];
+    const beforeData = {
+      conditional_trigger: 'No',
+      bar: 'asd',
+      foo: 'asd',
+    };
+    expect(
+      haveStepsChanged(steps, beforeData, {
+        conditional_trigger: 'Yes',
+        bar: 'asd',
+        foo: 'asd',
+      })
+    ).toEqual(true);
+    expect(
+      haveStepsChanged(steps, beforeData, {
+        conditional_trigger: 'No',
+        bar: 'qwe',
+        foo: 'asd',
+      })
+    ).toEqual(false);
   });
 });


### PR DESCRIPTION
**What**  
Fixed issue related to #55.

**The loogic behind it:**
After being redirect to a step from the summary, if the step answers are going to change the visible steps the next is not redirecting to the summary itself but is continuing to the normal flow of the form.

**How to test it**
- I created a branch for easy testing this `feature/multi-step-test`
- go to `/form/multi-step/step-a`
- on first step select **No**
- once in the summary go back to change the first step
- select **Yes**
- check that now you are going to **step b** instead of the summary