### PR TITLE
refactored APIs to not return empty record array as 404

### DIFF
--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -123,7 +123,15 @@ const Search = ({ query, type }) => {
                 <div style={{ textAlign: 'right' }}>{addNewPerson}</div>
               </div>
               <hr className="govuk-divider" />
-              <SearchResults records={results.records} />
+              {results.records?.length > 0 ? (
+                <SearchResults records={results.records} />
+              ) : (
+                <>
+                  <p className="govuk-body govuk-!-margin-top-5">
+                    {type.charAt(0).toUpperCase() + type.slice(1)} not found
+                  </p>
+                </>
+              )}
             </>
           )}
           <div style={{ height: '50px', textAlign: 'center' }}>
@@ -144,13 +152,7 @@ const Search = ({ query, type }) => {
             )}
           </div>
 
-          {error && (
-            <>
-              {' '}
-              <ErrorMessage label={error} />
-              {addNewPerson}
-            </>
-          )}
+          {error && <ErrorMessage label={error} />}
         </div>
       </div>
     </>

--- a/cypress/integration/search_by_name_adult_admin.js
+++ b/cypress/integration/search_by_name_adult_admin.js
@@ -15,7 +15,7 @@ describe('Adult group', () => {
       Cypress.env('CHILDREN_RECORD_LAST_NAME')
     );
     cy.get('[type="submit"]').click();
-    cy.get('.govuk-error-message').should('be.visible');
+    cy.contains('People not found').should('be.visible');
   });
 });
 

--- a/cypress/integration/search_by_name_children_admin.js
+++ b/cypress/integration/search_by_name_children_admin.js
@@ -38,6 +38,6 @@ describe('Children Group', () => {
       Cypress.env('ADULT_RECORD_LAST_NAME')
     );
     cy.get('[type="submit"]').click();
-    cy.get('.govuk-error-message').should('be.visible');
+    cy.contains('People not found').should('be.visible');
   });
 });

--- a/pages/api/cases/index.js
+++ b/pages/api/cases/index.js
@@ -11,11 +11,7 @@ export default async (req, res) => {
     case 'GET':
       try {
         const data = await getCases(req.query);
-        if (data?.cases?.length > 0) {
-          res.status(HttpStatus.OK).json(data);
-        } else {
-          res.status(HttpStatus.NOT_FOUND).json('Cases Not Found');
-        }
+        res.status(HttpStatus.OK).json(data);
       } catch (error) {
         console.log('Cases get error:', error.response.data);
         error?.response?.status === HttpStatus.NOT_FOUND

--- a/pages/api/residents/[id]/cases.js
+++ b/pages/api/residents/[id]/cases.js
@@ -11,11 +11,7 @@ export default async (req, res) => {
     case 'GET':
       try {
         const data = await getResidentCases(req.query.id);
-        if (data?.length > 0) {
-          res.status(HttpStatus.OK).json(data);
-        } else {
-          res.status(HttpStatus.NOT_FOUND).json('Cases Not Found');
-        }
+        res.status(HttpStatus.OK).json(data);
       } catch (error) {
         console.log(error.status);
         console.log('Cases get error:', error.response.data);

--- a/pages/api/residents/index.js
+++ b/pages/api/residents/index.js
@@ -11,11 +11,7 @@ export default async (req, res) => {
     case 'GET':
       try {
         const data = await getResidents(req.query);
-        if (data?.residents?.length > 0) {
-          res.status(HttpStatus.OK).json(data);
-        } else {
-          res.status(HttpStatus.NOT_FOUND).json('Residents Not Found');
-        }
+        res.status(HttpStatus.OK).json(data);
       } catch (error) {
         console.log('Residents get error:', error.response.data);
         error?.response?.status === HttpStatus.NOT_FOUND


### PR DESCRIPTION
**What**  
Our API layer was returning 404 if a record was `[]`.

```
{
    "residents": [],
    "nextCursor": ""
}
```

Now it's returning `[]`, instead of triggering an error.