### PR TITLE
Fixed cases date default sorting

### DIFF
--- a/components/Cases/Cases.jsx
+++ b/components/Cases/Cases.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import CasesTable from 'components/Cases/CasesTable';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
-import { getResidentCases } from 'utils/api/residents';
+import { getCasesByResident } from 'utils/api/cases';
 import Spinner from 'components/Spinner/Spinner';
 
 const Cases = ({ id }) => {
@@ -12,7 +12,7 @@ const Cases = ({ id }) => {
   const [cases, setCases] = useState();
   const getPersonCases = useCallback(async (id) => {
     try {
-      const data = await getResidentCases(id);
+      const data = await getCasesByResident(id);
       setLoading(false);
       setError(null);
       setCases(Array.isArray(data) ? data : [data]);

--- a/components/Cases/CasesTable.jsx
+++ b/components/Cases/CasesTable.jsx
@@ -2,15 +2,10 @@ import PropTypes from 'prop-types';
 import { formatDate } from 'utils/date';
 const onClick = (url) => window.open(url, '_blank');
 
-const CasesEntry = ({
-  formName,
-  caseFormUrl,
-  officerEmail,
-  caseFormTimestamp,
-}) => (
+const CasesEntry = ({ formName, caseFormUrl, officerEmail, dateOfEvent }) => (
   <tr className="govuk-table__row">
     <td className="govuk-table__cell govuk--timestamp">
-      {caseFormTimestamp && formatDate(caseFormTimestamp)}{' '}
+      {dateOfEvent && formatDate(dateOfEvent)}{' '}
     </td>
     <td className="govuk-table__cell">{formName}</td>
     <td className="govuk-table__cell">
@@ -32,7 +27,7 @@ const CasesTable = ({ records }) => (
   <table className="govuk-table">
     <tbody className="govuk-table__body">
       {records.map((result) => (
-        <CasesEntry key={result.personId} {...result} />
+        <CasesEntry key={result.recordId} {...result} />
       ))}
     </tbody>
   </table>
@@ -41,11 +36,11 @@ const CasesTable = ({ records }) => (
 CasesTable.propTypes = {
   records: PropTypes.arrayOf(
     PropTypes.shape({
-      personId: PropTypes.number.isRequired,
+      recordId: PropTypes.string.isRequired,
       formName: PropTypes.string.isRequired,
       caseFormUrl: PropTypes.string.isRequired,
       officerEmail: PropTypes.string.isRequired,
-      caseFormTimestamp: PropTypes.string.isRequired,
+      dateOfEvent: PropTypes.string.isRequired,
     })
   ).isRequired,
 };

--- a/components/Cases/CasesTable.spec.jsx
+++ b/components/Cases/CasesTable.spec.jsx
@@ -6,8 +6,8 @@ describe('CasesTable component', () => {
   const props = {
     records: [
       {
-        personId: 123,
-        caseFormTimestamp: '25/10/2020 13:49:43',
+        recordId: '123',
+        dateOfEvent: '25/10/2020 13:49:43',
         formName: 'foorm',
         caseFormUrl: 'https://foo.bar',
         officerEmail: 'Fname.Lname@hackney.gov.uk',

--- a/components/Search/results/CasesTable.jsx
+++ b/components/Search/results/CasesTable.jsx
@@ -10,7 +10,7 @@ const CasesEntry = ({
   caseFormUrl,
   dateOfBirth,
   officerEmail,
-  caseFormTimestamp,
+  dateOfEvent,
 }) => (
   <tr className="govuk-table__row">
     <td className="govuk-table__cell">
@@ -20,7 +20,7 @@ const CasesEntry = ({
       {isDateValid(dateOfBirth) && dateOfBirth}
     </td>
     <td className="govuk-table__cell">{officerEmail}</td>
-    <td className="govuk-table__cell">{formatDate(caseFormTimestamp)}</td>
+    <td className="govuk-table__cell">{formatDate(dateOfEvent)}</td>
     <td className="govuk-table__cell govuk-button--secondary'">
       <a
         href="#"
@@ -34,10 +34,10 @@ const CasesEntry = ({
 );
 
 const tableHeader = [
-  { id: 'client_name', text: 'Client Name' },
+  { id: 'first_name', text: 'Client Name' },
   { id: 'date_of_birth', text: 'Date of birth' },
-  { id: 'uploaded_by', text: 'Uploaded by' },
-  { id: 'last_upload', text: 'Last upload' },
+  { id: 'officer_email', text: 'Uploaded by' },
+  { id: 'date_of_event', text: 'Last upload' },
 ];
 
 const CasesTable = ({ records, sort = {}, onSort }) => {
@@ -64,7 +64,7 @@ const CasesTable = ({ records, sort = {}, onSort }) => {
       </thead>
       <tbody className="govuk-table__body">
         {records.map((result) => (
-          <CasesEntry key={result.personId} {...result} />
+          <CasesEntry key={result.recordId} {...result} />
         ))}
       </tbody>
     </table>
@@ -79,11 +79,11 @@ CasesTable.propTypes = {
   onSort: PropTypes.func.isRequired,
   records: PropTypes.arrayOf(
     PropTypes.shape({
-      personId: PropTypes.number.isRequired,
+      recordId: PropTypes.string.isRequired,
       formName: PropTypes.string.isRequired,
       caseFormUrl: PropTypes.string.isRequired,
       officerEmail: PropTypes.string.isRequired,
-      caseFormTimestamp: PropTypes.string.isRequired,
+      dateOfEvent: PropTypes.string.isRequired,
     })
   ).isRequired,
 };

--- a/components/Search/results/CasesTable.spec.jsx
+++ b/components/Search/results/CasesTable.spec.jsx
@@ -7,9 +7,9 @@ describe('CasesTable component', () => {
     onSort: jest.fn(),
     records: [
       {
-        personId: 123,
+        recordId: '123',
         dateOfBirth: '25/10/2000',
-        caseFormTimestamp: '25/10/2020 13:49:43',
+        dateOfEvent: '25/10/2020 13:49:43',
         firstName: 'foo',
         lastName: 'bar',
         formName: 'i am a form',
@@ -28,14 +28,14 @@ describe('CasesTable component', () => {
     const { asFragment, rerender } = render(
       <CasesTable
         {...props}
-        sort={{ order_by: 'desc', sort_by: 'client_name' }}
+        sort={{ order_by: 'desc', sort_by: 'first_name' }}
       />
     );
     expect(asFragment()).toMatchSnapshot();
     rerender(
       <CasesTable
         {...props}
-        sort={{ order_by: 'asc', sort_by: 'client_name' }}
+        sort={{ order_by: 'asc', sort_by: 'first_name' }}
       />
     );
     expect(asFragment()).toMatchSnapshot();
@@ -46,6 +46,6 @@ describe('CasesTable component', () => {
     expect(props.onSort).not.toHaveBeenCalled();
     fireEvent.click(getByText('Client Name'));
     expect(props.onSort).toHaveBeenCalled();
-    expect(props.onSort).toHaveBeenCalledWith('client_name');
+    expect(props.onSort).toHaveBeenCalledWith('first_name');
   });
 });

--- a/pages/api/residents/[id]/cases.js
+++ b/pages/api/residents/[id]/cases.js
@@ -1,6 +1,6 @@
 import * as HttpStatus from 'http-status-codes';
 
-import { getResidentCases } from 'utils/server/cases';
+import { getCasesByResident } from 'utils/server/cases';
 import { isAuthorised } from 'utils/auth';
 
 export default async (req, res) => {
@@ -10,7 +10,7 @@ export default async (req, res) => {
   switch (req.method) {
     case 'GET':
       try {
-        const data = await getResidentCases(req.query.id);
+        const data = await getCasesByResident(req.query.id);
         res.status(HttpStatus.OK).json(data);
       } catch (error) {
         console.log(error.status);

--- a/utils/api/cases.js
+++ b/utils/api/cases.js
@@ -7,6 +7,11 @@ export const getCases = async (params) => {
   return data;
 };
 
+export const getCasesByResident = async (id) => {
+  const { data } = await axios.get(`/api/residents/${id}/cases`);
+  return data;
+};
+
 export const addCase = async (formData) => {
   const { data } = await axios.post(`/api/cases`, formData);
   return data;

--- a/utils/api/cases.spec.js
+++ b/utils/api/cases.spec.js
@@ -17,6 +17,16 @@ describe('cases APIs', () => {
     });
   });
 
+  describe('getCasesByResident', () => {
+    it('should work properly', async () => {
+      axios.get.mockResolvedValue({ data: 'foobar' });
+      const data = await casesAPI.getCasesByResident('foo');
+      expect(axios.get).toHaveBeenCalled();
+      expect(axios.get.mock.calls[0][0]).toEqual('/api/residents/foo/cases');
+      expect(data).toEqual('foobar');
+    });
+  });
+
   describe('addCase', () => {
     it('should work properly', async () => {
       axios.post.mockResolvedValue({ data: 'foobar' });

--- a/utils/api/residents.js
+++ b/utils/api/residents.js
@@ -14,11 +14,6 @@ export const getResident = async (id, params) => {
   return data;
 };
 
-export const getResidentCases = async (id) => {
-  const { data } = await axios.get(`/api/residents/${id}/cases`);
-  return data;
-};
-
 export const addResident = async (formData) => {
   const { data } = await axios.post(`/api/residents`, formData);
   return data;

--- a/utils/api/residents.spec.js
+++ b/utils/api/residents.spec.js
@@ -28,16 +28,6 @@ describe('residents APIs', () => {
     });
   });
 
-  describe('getResidentCases', () => {
-    it('should work properly', async () => {
-      axios.get.mockResolvedValue({ data: 'foobar' });
-      const data = await residentsAPI.getResidentCases('foo');
-      expect(axios.get).toHaveBeenCalled();
-      expect(axios.get.mock.calls[0][0]).toEqual('/api/residents/foo/cases');
-      expect(data).toEqual('foobar');
-    });
-  });
-
   describe('addResident', () => {
     it('should work properly', async () => {
       axios.post.mockResolvedValue({ data: 'foobar' });

--- a/utils/server/cases.js
+++ b/utils/server/cases.js
@@ -15,7 +15,7 @@ export const getCases = async (params) => {
   return data;
 };
 
-export const getResidentCases = async (mosaic_id) => {
+export const getCasesByResident = async (mosaic_id) => {
   const { data } = await axios.get(`${ENDPOINT_API}/cases`, {
     headers: { 'x-api-key': AWS_KEY },
     params: { mosaic_id },

--- a/utils/server/cases.spec.js
+++ b/utils/server/cases.spec.js
@@ -22,10 +22,10 @@ describe('cases APIs', () => {
     });
   });
 
-  describe('getResidentCases', () => {
+  describe('getCasesByResident', () => {
     it('should work properly', async () => {
       axios.get.mockResolvedValue({ data: { foo: 123, cases: 'bar' } });
-      const data = await casesAPI.getResidentCases(123);
+      const data = await casesAPI.getCasesByResident(123);
       expect(axios.get).toHaveBeenCalled();
       expect(axios.get.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/cases`);
       expect(axios.get.mock.calls[0][1].headers).toEqual({


### PR DESCRIPTION
**What**  
- Used `dateOfEvent` instead of `caseFormTimestamp` for cases
- Fixed proptypes error for casesTable
- `getResidentCases` was move from `utils/api/residents` to `utils/api/cases` and renamed `getCasesByResident`
