### PR TITLE
Radio can now have key/values options

### DIFF
--- a/components/Form/DatePicker/DatePicker.jsx
+++ b/components/Form/DatePicker/DatePicker.jsx
@@ -18,7 +18,7 @@ const DatePicker = ({
       })}
     >
       <label className={`govuk-label govuk-label--${labelSize}`} htmlFor={name}>
-        {label} <span className="govuk-required">{required ? '*' : null}</span>
+        {label} {required && <span className="govuk-required">*</span>}
       </label>
       {hint && (
         <span id={`${name}-hint`} className="govuk-hint">

--- a/components/Form/Radios/Radios.jsx
+++ b/components/Form/Radios/Radios.jsx
@@ -36,28 +36,32 @@ const Radio = ({
     <div
       className={cx('govuk-radios', { 'govuk-radios--inline': isRadiosInline })}
     >
-      {options.map((option) => (
-        <div className="govuk-radios__item" key={option}>
-          <input
-            className={cx('govuk-radios__input', {
-              'govuk-input--error': error,
-            })}
-            id={`${name}_${option}`}
-            name={name}
-            type="radio"
-            value={option}
-            ref={register}
-            aria-describedby={hint && `${name}-hint`}
-            {...otherProps}
-          />
-          <label
-            className="govuk-label govuk-radios__label"
-            htmlFor={`${name}_${option}`}
-          >
-            {option}
-          </label>
-        </div>
-      ))}
+      {options.map((option) => {
+        const { value, text } =
+          typeof option === 'string' ? { value: option, text: option } : option;
+        return (
+          <div className="govuk-radios__item" key={text}>
+            <input
+              className={cx('govuk-radios__input', {
+                'govuk-input--error': error,
+              })}
+              id={`${name}_${value}`}
+              name={name}
+              type="radio"
+              value={value}
+              ref={register}
+              aria-describedby={hint && `${name}-hint`}
+              {...otherProps}
+            />
+            <label
+              className="govuk-label govuk-radios__label"
+              htmlFor={`${name}_${value}`}
+            >
+              {text}
+            </label>
+          </div>
+        );
+      })}
     </div>
   </div>
 );

--- a/components/Form/Radios/Radios.jsx
+++ b/components/Form/Radios/Radios.jsx
@@ -24,7 +24,7 @@ const Radio = ({
     })}
   >
     <label className={`govuk-label govuk-label--${labelSize}`} htmlFor={name}>
-      {label} <span className="govuk-required">{required ? '*' : null}</span>
+      {label} {required && <span className="govuk-required">*</span>}
     </label>
     {hint && (
       <span id={`${name}-hint`} className="govuk-hint">

--- a/components/Form/Select/Nationality.jsx
+++ b/components/Form/Select/Nationality.jsx
@@ -22,7 +22,7 @@ const NationalityList = ({
       className={`govuk-label govuk-label--${labelSize}`}
       htmlFor="nationality"
     >
-      {label} <span className="govuk-required">{required ? '*' : null}</span>
+      {label} {required && <span className="govuk-required">*</span>}
     </label>
 
     {error && <ErrorMessage label={error.message} />}

--- a/components/Form/Select/Select.jsx
+++ b/components/Form/Select/Select.jsx
@@ -12,6 +12,7 @@ const Select = ({
   onChange,
   placeHolder = '',
   register,
+  required,
   error,
   children,
   isUnselectable = true,
@@ -24,7 +25,7 @@ const Select = ({
     })}
   >
     <label className={`govuk-label govuk-label--${labelSize}`} htmlFor={name}>
-      {label}
+      {label} {required && <span className="govuk-required">*</span>}
     </label>
     {hint && (
       <span id={`${name}-hint`} className="govuk-hint">
@@ -73,6 +74,7 @@ Select.propTypes = {
       }),
     ])
   ).isRequired,
+  required: PropTypes.bool,
   placeHolder: PropTypes.string,
   selected: PropTypes.string,
   register: PropTypes.func,

--- a/components/Form/TextInput/TextInput.jsx
+++ b/components/Form/TextInput/TextInput.jsx
@@ -22,7 +22,7 @@ const TextInput = ({
     })}
   >
     <label className={`govuk-label govuk-label--${labelSize}`} htmlFor={name}>
-      {label} <span className="govuk-required">{required ? '*' : null}</span>
+      {label} {required && <span className="govuk-required">*</span>}
     </label>
     {hint && (
       <span id={`${name}-hint`} className="govuk-hint">

--- a/components/Summary/Summary.jsx
+++ b/components/Summary/Summary.jsx
@@ -86,6 +86,14 @@ export const SummarySection = ({
                       ?.text,
             };
           }
+          if (component === 'DateInput') {
+            const date = formData[name].split('-');
+            return {
+              key: name,
+              title: label,
+              value: `${date[2]}-${date[1]}-${date[0]}`,
+            };
+          }
           return {
             key: name,
             title: label,

--- a/components/Summary/Summary.jsx
+++ b/components/Summary/Summary.jsx
@@ -56,7 +56,7 @@ export const SummarySection = ({
     <SummaryList
       list={components
         .filter(({ name }) => formData[name])
-        .map(({ component, name, label }) => {
+        .map(({ component, options, name, label }) => {
           if (component === 'AddressLookup') {
             const { address, postcode } = formData[name];
             return {
@@ -73,6 +73,17 @@ export const SummarySection = ({
                   <div>{postcode}</div>
                 </>
               ),
+            };
+          }
+          if (component === 'Radios' || component === 'Select') {
+            return {
+              key: name,
+              title: label,
+              value:
+                typeof options[0] === 'string'
+                  ? formData[name]
+                  : options.find((option) => option.value === formData[name])
+                      ?.text,
             };
           }
           return {


### PR DESCRIPTION
**What**
It's now possible defining `Radios` components as:
```
        {
          component: 'Radion',
          name: 'gender',
          label: 'Gender',
          options: [
            { value: 'F', text: 'Female' },
            { value: 'M', text: 'Male' },
            { value: 'U', text: 'Unknown' },
            { value: 'I', text: 'Indeterminated' },
          ],
        },
```

**Plus**
- Fixed how dates appear in summary (from `yyyy-mm-dd` to `dd-mm-yyyy`)
- Fixed Select visual required feedback
- Fixed conditional rendering of the required feedback

<img width="739" alt="Screenshot 2020-12-17 at 09 05 09" src="https://user-images.githubusercontent.com/435399/102470174-eeee7400-4053-11eb-9143-c33403f1e3e5.png">
