### PR TITLE
prevent search cases to break if dateOfEvent is null

### DIFF
--- a/components/Search/results/CasesTable.jsx
+++ b/components/Search/results/CasesTable.jsx
@@ -20,7 +20,9 @@ const CasesEntry = ({
       {isDateValid(dateOfBirth) && dateOfBirth}
     </td>
     <td className="govuk-table__cell">{officerEmail}</td>
-    <td className="govuk-table__cell">{formatDate(dateOfEvent)}</td>
+    <td className="govuk-table__cell">
+      {isDateValid(dateOfEvent) && formatDate(dateOfEvent)}
+    </td>
     <td className="govuk-table__cell govuk-button--secondary'">
       <a
         href="#"

--- a/utils/date.js
+++ b/utils/date.js
@@ -12,4 +12,4 @@ export const formatDate = (date) =>
     year: 'numeric',
   });
 
-export const isDateValid = (date) => isValid(parseDate(date));
+export const isDateValid = (date) => Boolean(date) && isValid(parseDate(date));

--- a/utils/date.spec.js
+++ b/utils/date.spec.js
@@ -18,6 +18,7 @@ describe('date util', () => {
     it('should work properly', () => {
       expect(isDateValid('22/09/1941')).toBe(true);
       expect(isDateValid('foo')).toBe(false);
+      expect(isDateValid(null)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
**What**  
Currently, the cases search is breaking if `dateOfEvent` is null.
We will check that the date is valid before formatting it.