### PR TITLE
Improvements on DateInput

### DIFF
--- a/components/Form/AddressLookup/AddressLookup.jsx
+++ b/components/Form/AddressLookup/AddressLookup.jsx
@@ -160,6 +160,7 @@ const AddressLookup = ({
             ...rules?.validate,
           },
         }}
+        defaultValue={control.defaultValuesRef.current[name] || null}
         onFocus={() => inputRef.current.focus()}
       />
       {(error || errorMessage) && (

--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -148,6 +148,11 @@ const DateInput = forwardRef(
   }
 );
 
+DateInput.propTypes = {
+  label: PropTypes.string,
+  labelSize: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
+  hint: PropTypes.string,
+  rules: PropTypes.shape({}),
 };
 
 const ControlledDateInput = ({ control, name, rules, ...otherProps }) => (
@@ -169,10 +174,7 @@ const ControlledDateInput = ({ control, name, rules, ...otherProps }) => (
 );
 
 ControlledDateInput.propTypes = {
-  label: PropTypes.string,
-  labelSize: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
   name: PropTypes.string.isRequired,
-  hint: PropTypes.string,
   rules: PropTypes.shape({}),
   control: PropTypes.object.isRequired,
 };

--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -74,7 +74,7 @@ const DateInput = forwardRef(
                   id={`${name}-day`}
                   name={`${name}-day`}
                   type="text"
-                  pattern="[0-9]*"
+                  pattern="^\d{1,2}$"
                   inputMode="numeric"
                   value={date.day}
                   onChange={({ target: { value } }) =>
@@ -103,7 +103,7 @@ const DateInput = forwardRef(
                   id={`${name}-month`}
                   name={`${name}-month`}
                   type="text"
-                  pattern="[0-9]*"
+                  pattern="^\d{1,2}$"
                   inputMode="numeric"
                   value={date.month}
                   onChange={({ target: { value } }) =>
@@ -131,7 +131,7 @@ const DateInput = forwardRef(
                   id={`${name}-year`}
                   name={`${name}-year`}
                   type="text"
-                  pattern="[0-9]*"
+                  pattern="^\d{4}$"
                   inputMode="numeric"
                   value={date.year}
                   onChange={({ target: { value } }) =>

--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -181,6 +181,7 @@ const ControlledDateInput = ({
   );
 };
 
+    defaultValue={control.defaultValuesRef.current[name] || null}
 ControlledDateInput.propTypes = {
   label: PropTypes.string,
   labelSize: PropTypes.oneOf(['s', 'm', 'l', 'xl']),

--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, forwardRef, useRef } from 'react';
+import { useState, useEffect, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Controller } from 'react-hook-form';

--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, forwardRef, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Controller } from 'react-hook-form';
@@ -11,177 +11,163 @@ const getInitialDate = (value) => {
   return { day, month, year };
 };
 
-const DateInput = ({
-  label,
-  labelSize = 'm',
-  inputRef,
-  error,
-  hint,
-  value,
-  name,
-  onChange,
-  required,
-  ...otherProps
-}) => {
-  const [date, setDate] = useState(getInitialDate(value));
-  useEffect(() => {
-    const { day, month, year } = date;
-    day !== '' &&
-      month !== '' &&
-      year !== '' &&
-      onChange(`${year}-${month}-${day}`);
-    day === '' && month === '' && year === '' && onChange();
-  }, [date]);
-  return (
-    <div
-      className={cx('govuk-form-group', {
-        'govuk-form-group--error': error,
-      })}
-    >
-      <fieldset
-        className="govuk-fieldset"
-        role="group"
-        aria-describedby={`${name}-hint`}
+const DateInput = forwardRef(
+  (
+    {
+      label,
+      labelSize = 'm',
+      error,
+      hint,
+      value,
+      name,
+      onChange,
+      required,
+      ...otherProps
+    },
+    ref
+  ) => {
+    const [date, setDate] = useState(getInitialDate(value));
+    useEffect(() => {
+      const { day, month, year } = date;
+      day !== '' &&
+        month !== '' &&
+        year !== '' &&
+        onChange(`${year}-${month}-${day}`);
+      day === '' && month === '' && year === '' && onChange();
+    }, [date]);
+    return (
+      <div
+        className={cx('govuk-form-group', {
+          'govuk-form-group--error': error,
+        })}
       >
-        <legend
-          className={`govuk-fieldset__legend govuk-fieldset__legend--${labelSize}`}
+        <fieldset
+          className="govuk-fieldset"
+          role="group"
+          aria-describedby={`${name}-hint`}
         >
-          {label} {required && <span className="govuk-required">*</span>}
-        </legend>
-        <span id={`${name}-hint`} className="govuk-hint">
-          {hint}
-        </span>
-        {error && <ErrorMessage label={error.message} />}
-        <div className="govuk-date-input" id={name}>
-          <div className="govuk-date-input__item">
-            <div className="govuk-form-group">
-              <label
-                className="govuk-label govuk-date-input__label"
-                htmlFor={`${name}-day`}
-              >
-                Day
-              </label>
-              <input
-                className={cx(
-                  'govuk-input govuk-date-input__input govuk-input--width-2',
-                  {
-                    'govuk-input--error': error,
+          <legend
+            className={`govuk-fieldset__legend govuk-fieldset__legend--${labelSize}`}
+          >
+            {label} {required && <span className="govuk-required">*</span>}
+          </legend>
+          <span id={`${name}-hint`} className="govuk-hint">
+            {hint}
+          </span>
+          {error && <ErrorMessage label={error.message} />}
+          <div className="govuk-date-input" id={name}>
+            <div className="govuk-date-input__item">
+              <div className="govuk-form-group">
+                <label
+                  className="govuk-label govuk-date-input__label"
+                  htmlFor={`${name}-day`}
+                >
+                  Day
+                </label>
+                <input
+                  className={cx(
+                    'govuk-input govuk-date-input__input govuk-input--width-2',
+                    {
+                      'govuk-input--error': error,
+                    }
+                  )}
+                  id={`${name}-day`}
+                  name={`${name}-day`}
+                  type="text"
+                  pattern="[0-9]*"
+                  inputMode="numeric"
+                  value={date.day}
+                  onChange={({ target: { value } }) =>
+                    setDate({ ...date, day: value })
                   }
-                )}
-                id={`${name}-day`}
-                name={`${name}-day`}
-                type="text"
-                pattern="[0-9]*"
-                inputMode="numeric"
-                value={date.day}
-                onChange={({ target: { value } }) =>
-                  setDate({ ...date, day: value })
-                }
-                ref={inputRef}
-                {...otherProps}
-              />
+                  ref={ref}
+                  {...otherProps}
+                />
+              </div>
+            </div>
+            <div className="govuk-date-input__item">
+              <div className="govuk-form-group">
+                <label
+                  className="govuk-label govuk-date-input__label"
+                  htmlFor={`${name}-month`}
+                >
+                  Month
+                </label>
+                <input
+                  className={cx(
+                    'govuk-input govuk-date-input__input govuk-input--width-2',
+                    {
+                      'govuk-input--error': error,
+                    }
+                  )}
+                  id={`${name}-month`}
+                  name={`${name}-month`}
+                  type="text"
+                  pattern="[0-9]*"
+                  inputMode="numeric"
+                  value={date.month}
+                  onChange={({ target: { value } }) =>
+                    setDate({ ...date, month: value })
+                  }
+                  {...otherProps}
+                />
+              </div>
+            </div>
+            <div className="govuk-date-input__item">
+              <div className="govuk-form-group">
+                <label
+                  className="govuk-label govuk-date-input__label"
+                  htmlFor={`${name}-year`}
+                >
+                  Year
+                </label>
+                <input
+                  className={cx(
+                    'govuk-input govuk-date-input__input govuk-input--width-4',
+                    {
+                      'govuk-input--error': error,
+                    }
+                  )}
+                  id={`${name}-year`}
+                  name={`${name}-year`}
+                  type="text"
+                  pattern="[0-9]*"
+                  inputMode="numeric"
+                  value={date.year}
+                  onChange={({ target: { value } }) =>
+                    setDate({ ...date, year: value })
+                  }
+                  {...otherProps}
+                />
+              </div>
             </div>
           </div>
-          <div className="govuk-date-input__item">
-            <div className="govuk-form-group">
-              <label
-                className="govuk-label govuk-date-input__label"
-                htmlFor={`${name}-month`}
-              >
-                Month
-              </label>
-              <input
-                className={cx(
-                  'govuk-input govuk-date-input__input govuk-input--width-2',
-                  {
-                    'govuk-input--error': error,
-                  }
-                )}
-                id={`${name}-month`}
-                name={`${name}-month`}
-                type="text"
-                pattern="[0-9]*"
-                inputMode="numeric"
-                value={date.month}
-                onChange={({ target: { value } }) =>
-                  setDate({ ...date, month: value })
-                }
-                {...otherProps}
-              />
-            </div>
-          </div>
-          <div className="govuk-date-input__item">
-            <div className="govuk-form-group">
-              <label
-                className="govuk-label govuk-date-input__label"
-                htmlFor={`${name}-year`}
-              >
-                Year
-              </label>
-              <input
-                className={cx(
-                  'govuk-input govuk-date-input__input govuk-input--width-4',
-                  {
-                    'govuk-input--error': error,
-                  }
-                )}
-                id={`${name}-year`}
-                name={`${name}-year`}
-                type="text"
-                pattern="[0-9]*"
-                inputMode="numeric"
-                value={date.year}
-                onChange={({ target: { value } }) =>
-                  setDate({ ...date, year: value })
-                }
-                {...otherProps}
-              />
-            </div>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  );
+        </fieldset>
+      </div>
+    );
+  }
+);
+
 };
 
-const ControlledDateInput = ({
-  control,
-  name,
-  rules,
-  label,
-  hint,
-  ...otherProps
-}) => {
-  const inputRef = useRef();
-  return (
-    <Controller
-      as={
-        <DateInput
-          inputRef={inputRef}
-          hint={hint}
-          label={label}
-          rules={rules}
-          name={name}
-          {...otherProps}
-        />
-      }
-      onChange={([value]) => value}
-      name={name}
-      rules={{
-        ...rules,
-        validate: {
-          ...rules?.validate,
-          valid: (value) =>
-            value && (isValid(new Date(value)) || 'Must be a is valid Date'),
-        },
-      }}
-      onFocus={() => inputRef.current.focus()}
-      control={control}
-    ></Controller>
-  );
-};
-
+const ControlledDateInput = ({ control, name, rules, ...otherProps }) => (
+  <Controller
+    as={<DateInput {...otherProps} />}
+    onChange={([value]) => value}
+    name={name}
+    rules={{
+      ...rules,
+      validate: {
+        ...rules?.validate,
+        valid: (value) =>
+          value && (isValid(new Date(value)) || 'Must be a is valid Date'),
+      },
+    }}
+    control={control}
     defaultValue={control.defaultValuesRef.current[name] || null}
+  />
+);
+
 ControlledDateInput.propTypes = {
   label: PropTypes.string,
   labelSize: PropTypes.oneOf(['s', 'm', 'l', 'xl']),


### PR DESCRIPTION
**What**  
- prevent annoying warning message of uncontrolled controller (see [this discussion](https://github.com/react-hook-form/react-hook-form/discussions/3653) for more info)
- fixed dateInput ref (on error it should focus on the date input)
- force the date year to 4 digits (preventing `12-21-13` to be flag as valid date)