### PR TITLE
removed check that must be a number and used only one endpoint

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,10 +1,8 @@
 # ENV
 
 # Endpoints
-AWS_AUTHORIZATION=
 AWS_KEY=
 ENDPOINT_API=
-ENDPOINT_MOSAIC=
 
 # Hackney authorised Google user groups
 GSSO_URL =

--- a/components/Search/forms/SearchResidentsForm.jsx
+++ b/components/Search/forms/SearchResidentsForm.jsx
@@ -87,12 +87,7 @@ const SearchResidentsForm = ({ onFormSubmit, query }) => {
             inputClassName="govuk-input--width-10"
             inputMode="numeric"
             error={errors.mosaicId}
-            register={register({
-              pattern: {
-                value: /^[0-9]+$/,
-                message: 'Mosaic ID must be a number',
-              },
-            })}
+            register={register}
           />
         </div>
       </div>

--- a/pages/api/residents/[id]/index.js
+++ b/pages/api/residents/[id]/index.js
@@ -11,7 +11,9 @@ export default async (req, res) => {
     case 'GET':
       try {
         const data = await getResident(req.query.id);
-        res.status(HttpStatus.OK).json(data);
+        data
+          ? res.status(HttpStatus.OK).json(data)
+          : res.status(HttpStatus.NOT_FOUND).json('Resident Not Found');
       } catch (error) {
         console.log('Resident get error:', error.response.data);
         error?.response?.status === HttpStatus.NOT_FOUND

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,9 +33,7 @@ functions:
       securityGroupIds: ${self:custom.securityGroups.${self:provider.stage}}
       subnetIds: ${self:custom.subnets.${self:provider.stage}}
     environment:
-      AWS_AUTHORIZATION: ${ssm:/lbh-social-care/${self:provider.stage}/aws-authorization}
       AWS_KEY: ${ssm:/lbh-social-care/${self:provider.stage}/aws-key}
-      ENDPOINT_MOSAIC: ${ssm:/lbh-social-care/${self:provider.stage}/endpoint-mosaic}
       ENDPOINT_API: ${ssm:/lbh-social-care/${self:provider.stage}/endpoint-case-viewer}
       GSSO_URL: ${ssm:/lbh-social-care/${self:provider.stage}/gsso-url}
       GSSO_TOKEN_NAME: ${ssm:/lbh-social-care/${self:provider.stage}/gsso-token-name}
@@ -62,7 +60,7 @@ resources:
             SslSupportMethod: sni-only
           DefaultCacheBehavior:
             TargetOriginId: ${self:service}-${self:provider.stage}-custom-origin
-            ViewerProtocolPolicy: "redirect-to-https"
+            ViewerProtocolPolicy: 'redirect-to-https'
             AllowedMethods:
               - GET
               - HEAD
@@ -91,7 +89,7 @@ resources:
 custom:
   domain-name:
     Fn::Join:
-      - "."
+      - '.'
       - - Ref: ApiGatewayRestApi
         - execute-api
         - eu-west-2

--- a/utils/server/residents.js
+++ b/utils/server/residents.js
@@ -13,11 +13,11 @@ export const getResidents = async (params) => {
 };
 
 export const getResident = async (id, params) => {
-  const { data } = await axios.get(`${ENDPOINT_API}/residents/${id}`, {
+  const { data } = await axios.get(`${ENDPOINT_API}/residents`, {
     headers,
-    params,
+    params: { mosaic_id: id, ...params },
   });
-  return data;
+  return data?.residents?.[0];
 };
 
 export const addResident = async (formData) => {

--- a/utils/server/residents.js
+++ b/utils/server/residents.js
@@ -1,27 +1,20 @@
 import axios from 'axios';
 
-const {
-  ENDPOINT_MOSAIC,
-  ENDPOINT_API,
-  AWS_AUTHORIZATION,
-  AWS_KEY,
-} = process.env;
+const { ENDPOINT_API, AWS_KEY } = process.env;
+
+const headers = { 'x-api-key': AWS_KEY };
 
 export const getResidents = async (params) => {
-  const { data } = await axios.get(`${ENDPOINT_MOSAIC}/residents`, {
-    headers: {
-      Authorization: AWS_AUTHORIZATION,
-    },
+  const { data } = await axios.get(`${ENDPOINT_API}/residents`, {
+    headers,
     params,
   });
   return data;
 };
 
 export const getResident = async (id, params) => {
-  const { data } = await axios.get(`${ENDPOINT_MOSAIC}/residents/${id}`, {
-    headers: {
-      Authorization: AWS_AUTHORIZATION,
-    },
+  const { data } = await axios.get(`${ENDPOINT_API}/residents/${id}`, {
+    headers,
     params,
   });
   return data;
@@ -29,7 +22,7 @@ export const getResident = async (id, params) => {
 
 export const addResident = async (formData) => {
   const { data } = await axios.post(`${ENDPOINT_API}/residents`, formData, {
-    headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
+    headers: { ...headers, 'Content-Type': 'application/json' },
   });
   return data;
 };

--- a/utils/server/residents.spec.js
+++ b/utils/server/residents.spec.js
@@ -4,12 +4,7 @@ import * as residentsAPI from './residents';
 
 jest.mock('axios');
 
-const {
-  ENDPOINT_MOSAIC,
-  ENDPOINT_API,
-  AWS_AUTHORIZATION,
-  AWS_KEY,
-} = process.env;
+const { ENDPOINT_API, AWS_KEY } = process.env;
 
 describe('residents APIs', () => {
   describe('getResidents', () => {
@@ -19,11 +14,9 @@ describe('residents APIs', () => {
         foo: 'bar',
       });
       expect(axios.get).toHaveBeenCalled();
-      expect(axios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_MOSAIC}/residents`
-      );
+      expect(axios.get.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/residents`);
       expect(axios.get.mock.calls[0][1].headers).toEqual({
-        Authorization: AWS_AUTHORIZATION,
+        'x-api-key': AWS_KEY,
       });
       expect(data).toEqual({ foo: 123, residents: 'bar' });
     });
@@ -35,10 +28,10 @@ describe('residents APIs', () => {
       const data = await residentsAPI.getResident('foo', { bar: 'foobar' });
       expect(axios.get).toHaveBeenCalled();
       expect(axios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_MOSAIC}/residents/foo`
+        `${ENDPOINT_API}/residents/foo`
       );
       expect(axios.get.mock.calls[0][1].headers).toEqual({
-        Authorization: AWS_AUTHORIZATION,
+        'x-api-key': AWS_KEY,
       });
       expect(axios.get.mock.calls[0][1].params).toEqual({ bar: 'foobar' });
       expect(data).toEqual('foobar');

--- a/utils/server/residents.spec.js
+++ b/utils/server/residents.spec.js
@@ -24,16 +24,19 @@ describe('residents APIs', () => {
 
   describe('getResident', () => {
     it('should work properly', async () => {
-      axios.get.mockResolvedValue({ data: 'foobar' });
+      axios.get.mockResolvedValue({
+        data: { residents: ['foobar', 'barfoo'] },
+      });
       const data = await residentsAPI.getResident('foo', { bar: 'foobar' });
       expect(axios.get).toHaveBeenCalled();
-      expect(axios.get.mock.calls[0][0]).toEqual(
-        `${ENDPOINT_API}/residents/foo`
-      );
+      expect(axios.get.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/residents`);
       expect(axios.get.mock.calls[0][1].headers).toEqual({
         'x-api-key': AWS_KEY,
       });
-      expect(axios.get.mock.calls[0][1].params).toEqual({ bar: 'foobar' });
+      expect(axios.get.mock.calls[0][1].params).toEqual({
+        mosaic_id: 'foo',
+        bar: 'foobar',
+      });
       expect(data).toEqual('foobar');
     });
   });


### PR DESCRIPTION
**What**  
- removed check that must be a number
- used cases API endpoint for resident
- mapped getResident on getResidents (so we can just use one endpoint)