### PR TITLE
wrapped API message error in a object aligned with aws

### DIFF
--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -15,7 +15,7 @@ const AllocatedWorkers = ({ id }) => {
       const data = await getAllocatedWorkers(id);
       setAllocWorkers(data.allocations);
     } catch (e) {
-      setError(e.response?.data || 'Oops an error occurred');
+      setError(e.response?.data?.message || 'Oops an error occurred');
     }
     setLoading(false);
   });

--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -15,7 +15,7 @@ const AllocatedWorkers = ({ id }) => {
       const data = await getAllocatedWorkers(id);
       setAllocWorkers(data.allocations);
     } catch (e) {
-      setError(e.response?.data?.message || 'Oops an error occurred');
+      setError(true);
     }
     setLoading(false);
   });
@@ -31,7 +31,7 @@ const AllocatedWorkers = ({ id }) => {
       ) : (
         <>
           {allocWorkers && <AllocatedWorkersTable records={allocWorkers} />}
-          {error && <ErrorMessage label={error} />}
+          {error && <ErrorMessage />}
         </>
       )}
     </>

--- a/components/Cases/Cases.jsx
+++ b/components/Cases/Cases.jsx
@@ -15,14 +15,14 @@ const Cases = ({ id }) => {
     try {
       const data = await getCasesByResident(id, { cursor });
       setLoading(false);
-      setError(null);
+      setError(false);
       setResults({
         ...data,
         cases: [...(results?.cases || []), ...data.cases],
       });
     } catch (e) {
       setLoading(false);
-      setError(e.response?.data?.message || 'Oops an error occurred');
+      setError(true);
     }
   });
   useEffect(() => {
@@ -73,7 +73,7 @@ const Cases = ({ id }) => {
               )
             )}
           </div>
-          {error && <ErrorMessage label={error} />}
+          {error && <ErrorMessage />}
         </>
       )}
     </>

--- a/components/Cases/Cases.jsx
+++ b/components/Cases/Cases.jsx
@@ -22,7 +22,7 @@ const Cases = ({ id }) => {
       });
     } catch (e) {
       setLoading(false);
-      setError(e.response?.data || 'Oops an error occurred');
+      setError(e.response?.data?.message || 'Oops an error occurred');
     }
   });
   useEffect(() => {

--- a/components/ErrorMessage/ErrorMessage.jsx
+++ b/components/ErrorMessage/ErrorMessage.jsx
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
-const ErrorMessage = ({ label, className }) => (
+const ErrorMessage = ({ label = 'Oops an error occurred', className }) => (
   <span className={cx('govuk-error-message', className)}>
     <span className="govuk-visually-hidden">Error:</span> {label}
   </span>
 );
 
 ErrorMessage.propTypes = {
-  label: PropTypes.node.isRequired,
+  label: PropTypes.node,
   className: PropTypes.string,
 };
 

--- a/components/ErrorMessage/ErrorMessage.spec.jsx
+++ b/components/ErrorMessage/ErrorMessage.spec.jsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+
+import ErrorMessage from './ErrorMessage';
+
+describe('ErrorMessage component', () => {
+  it('should render properly', () => {
+    const { asFragment } = render(<ErrorMessage label="I am an error" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render properly with the default message', () => {
+    const { asFragment } = render(<ErrorMessage />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/ErrorMessage/__snapshots__/ErrorMessage.spec.jsx.snap
+++ b/components/ErrorMessage/__snapshots__/ErrorMessage.spec.jsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorMessage component should render properly 1`] = `
+<DocumentFragment>
+  <span
+    class="govuk-error-message"
+  >
+    <span
+      class="govuk-visually-hidden"
+    >
+      Error:
+    </span>
+     I am an error
+  </span>
+</DocumentFragment>
+`;
+
+exports[`ErrorMessage component should render properly with the default message 1`] = `
+<DocumentFragment>
+  <span
+    class="govuk-error-message"
+  >
+    <span
+      class="govuk-visually-hidden"
+    >
+      Error:
+    </span>
+     Oops an error occurred
+  </span>
+</DocumentFragment>
+`;

--- a/components/Form/AddressLookup/AddressLookup.jsx
+++ b/components/Form/AddressLookup/AddressLookup.jsx
@@ -63,7 +63,7 @@ const AddressLookup = ({
       return;
     }
     setIsManually(false);
-    setError(null);
+    setError(false);
     setResults([]);
     try {
       const res = await lookupPostcode(postcode);

--- a/components/PersonView/PersonView.jsx
+++ b/components/PersonView/PersonView.jsx
@@ -19,7 +19,7 @@ const PersonView = ({ personId, expandView }) => {
       setError(null);
     } catch (e) {
       setPerson(null);
-      setError(e.response?.data || 'Oops an error occurred');
+      setError(e.response?.data?.message || 'Oops an error occurred');
     }
     setLoading(false);
   };

--- a/components/PersonView/PersonView.jsx
+++ b/components/PersonView/PersonView.jsx
@@ -16,10 +16,10 @@ const PersonView = ({ personId, expandView }) => {
     try {
       const data = await getResident(personId);
       setPerson(data);
-      setError(null);
+      setError(false);
     } catch (e) {
       setPerson(null);
-      setError(e.response?.data?.message || 'Oops an error occurred');
+      setError(true);
     }
     setLoading(false);
   };
@@ -32,7 +32,7 @@ const PersonView = ({ personId, expandView }) => {
         <Spinner />
       ) : (
         <>
-          {error && <ErrorMessage label={error} />}
+          {error && <ErrorMessage />}
           {person && (
             <>
               {!expandView && (

--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -56,14 +56,13 @@ const Search = ({ query, type }) => {
   const onFormSubmit = useCallback(async (formData, records = []) => {
     setLoading(true);
     !formData.cursor && setResults(null);
-    setError(null);
+    setError(false);
     try {
       setFormData(formData);
       const data = await searchFunction({
         ...formData,
         context_flag: user.permissionFlag,
       });
-      setLoading(false);
       setResults({
         ...data,
         records: [...records, ...getRecords(data)],
@@ -73,9 +72,9 @@ const Search = ({ query, type }) => {
         shallow: true,
       });
     } catch (e) {
-      setLoading(false);
-      setError(e.response?.data?.message || 'Oops an error occurred');
+      setError(true);
     }
+    setLoading(false);
   });
 
   // commented out as the feature is not ready in the BE
@@ -182,8 +181,7 @@ const Search = ({ query, type }) => {
               )
             )}
           </div>
-
-          {error && <ErrorMessage label={error} />}
+          {error && <ErrorMessage />}
         </div>
       </div>
     </>

--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -74,7 +74,7 @@ const Search = ({ query, type }) => {
       });
     } catch (e) {
       setLoading(false);
-      setError(e.response?.data || 'Oops an error occurred');
+      setError(e.response?.data?.message || 'Oops an error occurred');
     }
   });
 

--- a/components/Search/Search.spec.jsx
+++ b/components/Search/Search.spec.jsx
@@ -72,9 +72,7 @@ describe(`Search`, () => {
   });
 
   it('should work properly on search fails', async () => {
-    getResidents.mockImplementation(() =>
-      Promise.reject({ response: { data: 'I am an ERROR' } })
-    );
+    getResidents.mockImplementation(() => Promise.reject());
     const { getByRole, getByLabelText, queryByText } = render(
       <UserContext.Provider
         value={{
@@ -90,6 +88,6 @@ describe(`Search`, () => {
       fireEvent.submit(getByRole('form'));
     });
     // expect(queryByText('Add New Person')).toBeInTheDocument();
-    expect(queryByText('I am an ERROR')).toBeInTheDocument();
+    expect(queryByText('Oops an error occurred')).toBeInTheDocument();
   });
 });

--- a/pages/api/cases/index.js
+++ b/pages/api/cases/index.js
@@ -5,7 +5,9 @@ import { isAuthorised } from 'utils/auth';
 
 export default async (req, res) => {
   if (!isAuthorised({ req })) {
-    return res.status(HttpStatus.UNAUTHORIZED).send('Auth cookie missing.');
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
   }
   switch (req.method) {
     case 'GET':
@@ -15,10 +17,12 @@ export default async (req, res) => {
       } catch (error) {
         console.log('Cases get error:', error?.response?.data);
         error?.response?.status === HttpStatus.NOT_FOUND
-          ? res.status(HttpStatus.NOT_FOUND).json('Cases Not Found')
+          ? res
+              .status(HttpStatus.NOT_FOUND)
+              .json({ message: 'Cases Not Found' })
           : res
               .status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .json('Unable to get the Cases');
+              .json({ message: 'Unable to get the Cases' });
       }
       break;
 
@@ -30,11 +34,13 @@ export default async (req, res) => {
         console.log('Case post error:', error?.response?.data);
         res
           .status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .json('Unable to post case');
+          .json({ message: 'Unable to post case' });
       }
       break;
 
     default:
-      res.status(HttpStatus.BAD_REQUEST).json('Invalid request method');
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
   }
 };

--- a/pages/api/postcode/[postcode].js
+++ b/pages/api/postcode/[postcode].js
@@ -5,7 +5,9 @@ import { getAddresses } from 'utils/server/postcode';
 
 export default async (req, res) => {
   if (!isAuthorised({ req })) {
-    return res.status(HttpStatus.UNAUTHORIZED).send('Auth cookie missing.');
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
   }
   switch (req.method) {
     case 'GET':
@@ -16,11 +18,13 @@ export default async (req, res) => {
         console.log('Postcode get error', error?.response?.data);
         res
           .status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .end('Unable to get the Addresses');
+          .json({ message: 'Unable to get the Addresses' });
       }
       break;
 
     default:
-      res.status(HttpStatus.BAD_REQUEST).json('Invalid request method');
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
   }
 };

--- a/pages/api/residents/[id]/allocated-workers.js
+++ b/pages/api/residents/[id]/allocated-workers.js
@@ -5,7 +5,9 @@ import { isAuthorised } from 'utils/auth';
 
 export default async (req, res) => {
   if (!isAuthorised({ req })) {
-    return res.status(HttpStatus.UNAUTHORIZED).send('Auth cookie missing.');
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
   }
   switch (req.method) {
     case 'GET':
@@ -16,10 +18,12 @@ export default async (req, res) => {
       } catch (error) {
         console.log('Allocated Workers get error:', error?.response?.data);
         error?.response?.status === HttpStatus.NOT_FOUND
-          ? res.status(HttpStatus.NOT_FOUND).json('Allocated Workers Not Found')
+          ? res
+              .status(HttpStatus.NOT_FOUND)
+              .json({ message: 'Allocated Workers Not Found' })
           : res
               .status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .json('Unable to get the Allocated Workers');
+              .json({ message: 'Unable to get the Allocated Workers' });
       }
       break;
 
@@ -31,12 +35,14 @@ export default async (req, res) => {
     //     console.log('Allocated Workers post error:', error?.response?.data);
     //     res
     //       .status(HttpStatus.INTERNAL_SERVER_ERROR)
-    //       .json('Unable to post Allocated Workers');
+    //       .json({ message: 'Unable to post Allocated Workers'});
     //   }
     //   break;
 
     default:
-      res.status(HttpStatus.BAD_REQUEST).json('Invalid request method');
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
       console.log(res.status);
   }
 };

--- a/pages/api/residents/[id]/cases.js
+++ b/pages/api/residents/[id]/cases.js
@@ -5,7 +5,9 @@ import { isAuthorised } from 'utils/auth';
 
 export default async (req, res) => {
   if (!isAuthorised({ req })) {
-    return res.status(HttpStatus.UNAUTHORIZED).send('Auth cookie missing.');
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
   }
   const { id, ...params } = req.query;
   switch (req.method) {
@@ -17,11 +19,13 @@ export default async (req, res) => {
         console.log('Cases get error:', error?.response?.data);
         res
           .status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .json('Unable to get the Cases');
+          .json({ message: 'Unable to get the Cases' });
       }
       break;
 
     default:
-      res.status(HttpStatus.BAD_REQUEST).json('Invalid request method');
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
   }
 };

--- a/pages/api/residents/[id]/index.js
+++ b/pages/api/residents/[id]/index.js
@@ -5,7 +5,9 @@ import { isAuthorised } from 'utils/auth';
 
 export default async (req, res) => {
   if (!isAuthorised({ req })) {
-    return res.status(HttpStatus.UNAUTHORIZED).send('Auth cookie missing.');
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
   }
   switch (req.method) {
     case 'GET':
@@ -13,18 +15,24 @@ export default async (req, res) => {
         const data = await getResident(req.query.id);
         data
           ? res.status(HttpStatus.OK).json(data)
-          : res.status(HttpStatus.NOT_FOUND).json('Resident Not Found');
+          : res
+              .status(HttpStatus.NOT_FOUND)
+              .json({ message: 'Resident Not Found' });
       } catch (error) {
         console.log('Resident get error:', error?.response?.data);
         error?.response?.status === HttpStatus.NOT_FOUND
-          ? res.status(HttpStatus.NOT_FOUND).json('Resident Not Found')
+          ? res
+              .status(HttpStatus.NOT_FOUND)
+              .json({ message: 'Resident Not Found' })
           : res
               .status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .json('Unable to get the Resident');
+              .json({ message: 'Unable to get the Resident' });
       }
       break;
 
     default:
-      res.status(HttpStatus.BAD_REQUEST).json('Invalid request method');
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
   }
 };

--- a/pages/api/residents/index.js
+++ b/pages/api/residents/index.js
@@ -5,7 +5,9 @@ import { isAuthorised } from 'utils/auth';
 
 export default async (req, res) => {
   if (!isAuthorised({ req })) {
-    return res.status(HttpStatus.UNAUTHORIZED).send('Auth cookie missing.');
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
   }
   switch (req.method) {
     case 'GET':
@@ -15,10 +17,12 @@ export default async (req, res) => {
       } catch (error) {
         console.log('Residents get error:', error?.response?.data);
         error?.response?.status === HttpStatus.NOT_FOUND
-          ? res.status(HttpStatus.NOT_FOUND).json('Residents Not Found')
+          ? res
+              .status(HttpStatus.NOT_FOUND)
+              .json({ message: 'Residents Not Found' })
           : res
               .status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .json('Unable to get the Residents');
+              .json({ message: 'Unable to get the Residents' });
       }
       break;
 
@@ -30,11 +34,13 @@ export default async (req, res) => {
         console.log('Resident post error:', error?.response?.data);
         res
           .status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .json('Unable to add resident');
+          .json({ message: 'Unable to add resident' });
       }
       break;
 
     default:
-      res.status(HttpStatus.BAD_REQUEST).json('Invalid request method');
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
   }
 };


### PR DESCRIPTION
**What**  
When API is failing is returning an error with `{message: "internal server error"}` this is mimic the same behaviour in our API layer plus it's preventing the FE to fail (because it's trying to set an object as react child.

Also, show a generic error message, the user doesn't need to know what's wrong with the APIs.