### PR TITLE
Add allocated worker

### DIFF
--- a/__mocks__/react-modal.js
+++ b/__mocks__/react-modal.js
@@ -1,4 +1,7 @@
-const MockModal = ({ children }) => <div className="modal">{children}</div>;
+jest.mock('components/Icons/TimesCircle', () => () => 'MockedCloseButton');
+
+const MockModal = ({ isOpen, children }) =>
+  isOpen ? <div className="modal">{children}</div> : null;
 
 MockModal.setAppElement = jest.fn();
 

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
 
@@ -24,19 +24,19 @@ const AddAllocatedWorker = ({ personId, currentlyAllocated }) => {
     mode: 'onChange',
   });
   const { user } = useContext(UserContext);
-  const getAllocatedTeams = async () => {
+  const getAllocatedTeams = useCallback(async () => {
     try {
       const data = await getTeams();
       setTeams(data.teams);
     } catch (e) {
       setError(true);
     }
-  };
+  });
   useEffect(() => {
     getAllocatedTeams();
   }, []);
   const selectedTeam = watch('team');
-  const getAllocatedWorkers = async () => {
+  const getAllocatedWorkers = useCallback(async () => {
     setWorkers();
     try {
       const data = await getTeamWorkers(selectedTeam);
@@ -44,18 +44,18 @@ const AddAllocatedWorker = ({ personId, currentlyAllocated }) => {
     } catch (e) {
       setError(true);
     }
-  };
+  });
   useEffect(() => {
     selectedTeam && getAllocatedWorkers();
   }, [selectedTeam]);
   if (error) {
     return 'Oops an error occurred';
   }
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setIsModalOpen(false);
     setWorkers();
-  };
-  const addWorker = async (formData) => {
+  });
+  const addWorker = useCallback(async (formData) => {
     setPostLoading(true);
     setPostError();
     try {
@@ -65,7 +65,7 @@ const AddAllocatedWorker = ({ personId, currentlyAllocated }) => {
       setPostError(true);
     }
     setPostLoading(false);
-  };
+  });
   return (
     <>
       <div className="lbh-table-header">

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
@@ -80,7 +80,7 @@ const AddAllocatedWorker = ({ personId, currentlyAllocated }) => {
       </div>
       <hr className="govuk-divider" />
       <p>
-        <i>Optional</i>
+        <i>{currentlyAllocated === 0 ? 'Currently unallocated' : 'Optional'}</i>
       </p>
       <Modal isOpen={isModalOpen} onRequestClose={closeModal}>
         <h2 className="govuk-heading-l">Allocate worker</h2>

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
@@ -1,0 +1,185 @@
+import { useEffect, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import { useForm } from 'react-hook-form';
+
+import { Button, Radios } from 'components/Form';
+import Modal from 'components/Modal/Modal';
+import Spinner from 'components/Spinner/Spinner';
+import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
+import UserContext from 'components/UserContext/UserContext';
+import {
+  getTeams,
+  getTeamWorkers,
+  addAllocatedWorker,
+} from 'utils/api/allocatedWorkers';
+
+const AddAllocatedWorker = ({ personId, currentlyAllocated }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [teams, setTeams] = useState();
+  const [workers, setWorkers] = useState();
+  const [error, setError] = useState();
+  const [postError, setPostError] = useState();
+  const [postLoading, setPostLoading] = useState();
+  const { handleSubmit, register, watch } = useForm({
+    mode: 'onChange',
+  });
+  const { user } = useContext(UserContext);
+  const getAllocatedTeams = async () => {
+    try {
+      const data = await getTeams();
+      setTeams(data.teams);
+    } catch (e) {
+      setError(true);
+    }
+  };
+  useEffect(() => {
+    getAllocatedTeams();
+  }, []);
+  const selectedTeam = watch('team');
+  const getAllocatedWorkers = async () => {
+    setWorkers();
+    try {
+      const data = await getTeamWorkers(selectedTeam);
+      setWorkers(data.workers);
+    } catch (e) {
+      setError(true);
+    }
+  };
+  useEffect(() => {
+    selectedTeam && getAllocatedWorkers();
+  }, [selectedTeam]);
+  if (error) {
+    return 'Oops an error occurred';
+  }
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setWorkers();
+  };
+  const addWorker = async (formData) => {
+    setPostLoading(true);
+    setPostError();
+    try {
+      await addAllocatedWorker(personId, { user: user.email, ...formData });
+      closeModal();
+    } catch (e) {
+      setPostError(true);
+    }
+    setPostLoading(false);
+  };
+  return (
+    <>
+      <div className="lbh-table-header">
+        <h3 className="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0">
+          Allocated Worker {currentlyAllocated + 1}
+        </h3>
+        <Button
+          label="Allocate worker"
+          isSecondary
+          onClick={() => setIsModalOpen(true)}
+        />
+      </div>
+      <hr className="govuk-divider" />
+      <p>
+        <i>Optional</i>
+      </p>
+      <Modal isOpen={isModalOpen} onRequestClose={closeModal}>
+        <h2 className="govuk-heading-l">Allocate worker</h2>
+        <form role="form" onSubmit={handleSubmit(addWorker)}>
+          {teams && (
+            <Radios
+              name="team"
+              label="Select a team to view workers for that team"
+              labelSize="s"
+              options={teams.map(({ id, name }) => ({
+                value: id,
+                text: name,
+              }))}
+              register={register({ required: true })}
+            />
+          )}
+          {workers && (
+            <>
+              <h3>Information and Assessment workers</h3>
+              <p className="govuk-body">
+                Select a worker to allocate a case to them. You can view more
+                about a worker’s current allocated cases by selecting their
+                name.
+              </p>
+              <table className="govuk-table">
+                <thead className="govuk-table__head">
+                  <tr className="govuk-table__row">
+                    <th
+                      scope="col"
+                      className="govuk-table__header"
+                      style={{ width: '4rem' }}
+                    >
+                      Select
+                    </th>
+                    <th scope="col" className="govuk-table__header">
+                      Name
+                    </th>
+                    <th
+                      scope="col"
+                      className="govuk-table__header govuk-table__header--numeric"
+                    >
+                      Total Cases
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="govuk-table__body">
+                  {workers.map(({ firstName, lastName, id, totalcases }) => (
+                    <tr className="govuk-table__row govuk-radios" key={id}>
+                      <td className="govuk-table__cell">
+                        <div className="govuk-radios__item">
+                          <input
+                            aria-labelledby={`worker_${id}`}
+                            className="govuk-radios__input"
+                            name="worker"
+                            type="radio"
+                            value={id}
+                            ref={register}
+                          />
+                          <label className="govuk-label govuk-radios__label"></label>
+                        </div>
+                      </td>
+                      <td className="govuk-table__cell lbh-table__cell--va-middle">
+                        <a
+                          id={`worker_${id}`}
+                          href={`/workers/${id}`}
+                          className="govuk-link"
+                          rel="noopener"
+                          target="_blank"
+                        >
+                          {firstName} {lastName}
+                        </a>
+                      </td>
+                      <td className="govuk-table__cell govuk-table__cell--numeric">
+                        {totalcases}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <Button
+                label="Allocate worker"
+                type="submit"
+                disabled={postLoading}
+              />
+              {postError && (
+                <ErrorMessage label="There was an error allocating the worker. Please retry." />
+              )}
+            </>
+          )}
+          {selectedTeam && (!teams || !workers) && <Spinner />}
+        </form>
+      </Modal>
+    </>
+  );
+};
+
+AddAllocatedWorker.propTypes = {
+  personId: PropTypes.string.isRequired,
+  currentlyAllocated: PropTypes.number.isRequired,
+};
+
+export default AddAllocatedWorker;

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.jsx
@@ -1,0 +1,94 @@
+import { act, fireEvent, render } from '@testing-library/react';
+
+import UserContext from 'components/UserContext/UserContext';
+import AddAllocatedWorker from './AddAllocatedWorker';
+
+import {
+  getTeams,
+  getTeamWorkers,
+  addAllocatedWorker,
+} from 'utils/api/allocatedWorkers';
+
+jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
+
+jest.mock('utils/api/allocatedWorkers', () => ({
+  getTeams: jest.fn(),
+  getTeamWorkers: jest.fn(),
+  addAllocatedWorker: jest.fn(),
+}));
+
+describe(`AddAllocatedWorker`, () => {
+  getTeams.mockImplementation(() =>
+    Promise.resolve({
+      teams: [
+        { id: '1', name: 'Team 1' },
+        { id: '2', name: 'Team 2' },
+        { id: '3', name: 'Team 3' },
+      ],
+    })
+  );
+  getTeamWorkers.mockImplementation(() =>
+    Promise.resolve({
+      workers: [
+        { id: 'a', firstName: 'Worker', lastName: 'A' },
+        { id: 'b', firstName: 'Worker', lastName: 'B' },
+        { id: 'c', firstName: 'Worker', lastName: 'C' },
+      ],
+    })
+  );
+  const props = {
+    currentlyAllocated: 3,
+    personId: '123',
+  };
+
+  it('should render properly', async () => {
+    const { findByText, getByText, asFragment } = render(
+      <UserContext.Provider
+        value={{
+          user: { name: 'foo', email: 'foo@bar.com' },
+        }}
+      >
+        <AddAllocatedWorker {...props} type="people" />
+      </UserContext.Provider>
+    );
+    const showModalButton = getByText('Allocate worker');
+    fireEvent.click(showModalButton);
+    const teamRadio = await findByText(
+      'Select a team to view workers for that team'
+    );
+    expect(teamRadio).toBeInTheDocument();
+    const radioSelection = getByText('Team 1');
+    await act(async () => {
+      fireEvent.click(radioSelection);
+    });
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should post correctly properly to the API', async () => {
+    const { getByText, getByLabelText, getByRole } = render(
+      <UserContext.Provider
+        value={{
+          user: { name: 'foo', email: 'foo@bar.com' },
+        }}
+      >
+        <AddAllocatedWorker {...props} type="people" />
+      </UserContext.Provider>
+    );
+    await act(async () => {
+      fireEvent.click(getByText('Allocate worker'));
+    });
+    await act(async () => {
+      fireEvent.click(getByLabelText('Team 3'));
+    });
+    fireEvent.click(getByLabelText('Worker C'));
+    await act(async () => {
+      fireEvent.submit(getByRole('form'));
+    });
+    expect(addAllocatedWorker).toHaveBeenCalled();
+    expect(addAllocatedWorker).toHaveBeenCalledWith('123', {
+      user: 'foo@bar.com',
+      team: '3',
+      worker: 'c',
+    });
+  });
+});

--- a/components/AllocatedWorkers/AddAllocatedWorker/__snapshots__/AddAllocatedWorker.spec.jsx.snap
+++ b/components/AllocatedWorkers/AddAllocatedWorker/__snapshots__/AddAllocatedWorker.spec.jsx.snap
@@ -1,0 +1,278 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddAllocatedWorker should render properly 1`] = `
+<DocumentFragment>
+  <div
+    class="lbh-table-header"
+  >
+    <h3
+      class="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0"
+    >
+      Allocated Worker 4
+    </h3>
+    <button
+      class="govuk-button govuk-button--secondary"
+      data-module="govuk-button"
+    >
+      Allocate worker
+    </button>
+  </div>
+  <hr
+    class="govuk-divider"
+  />
+  <p>
+    <i>
+      Optional
+    </i>
+  </p>
+  <div
+    class="modal"
+  >
+    <button
+      class="closeButton"
+    >
+      MockedCloseButton
+    </button>
+    <div>
+      <h2
+        class="govuk-heading-l"
+      >
+        Allocate worker
+      </h2>
+      <form
+        role="form"
+      >
+        <div
+          class="govuk-form-group"
+        >
+          <label
+            class="govuk-label govuk-label--s"
+            for="team"
+          >
+            Select a team to view workers for that team 
+          </label>
+          <div
+            class="govuk-radios"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                id="team_1"
+                name="team"
+                type="radio"
+                value="1"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="team_1"
+              >
+                Team 1
+              </label>
+            </div>
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                id="team_2"
+                name="team"
+                type="radio"
+                value="2"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="team_2"
+              >
+                Team 2
+              </label>
+            </div>
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                class="govuk-radios__input"
+                id="team_3"
+                name="team"
+                type="radio"
+                value="3"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+                for="team_3"
+              >
+                Team 3
+              </label>
+            </div>
+          </div>
+        </div>
+        <h3>
+          Information and Assessment workers
+        </h3>
+        <p
+          class="govuk-body"
+        >
+          Select a worker to allocate a case to them. You can view more about a worker’s current allocated cases by selecting their name.
+        </p>
+        <table
+          class="govuk-table"
+        >
+          <thead
+            class="govuk-table__head"
+          >
+            <tr
+              class="govuk-table__row"
+            >
+              <th
+                class="govuk-table__header"
+                scope="col"
+                style="width: 4rem;"
+              >
+                Select
+              </th>
+              <th
+                class="govuk-table__header"
+                scope="col"
+              >
+                Name
+              </th>
+              <th
+                class="govuk-table__header govuk-table__header--numeric"
+                scope="col"
+              >
+                Total Cases
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="govuk-table__body"
+          >
+            <tr
+              class="govuk-table__row govuk-radios"
+            >
+              <td
+                class="govuk-table__cell"
+              >
+                <div
+                  class="govuk-radios__item"
+                >
+                  <input
+                    aria-labelledby="worker_a"
+                    class="govuk-radios__input"
+                    name="worker"
+                    type="radio"
+                    value="a"
+                  />
+                  <label
+                    class="govuk-label govuk-radios__label"
+                  />
+                </div>
+              </td>
+              <td
+                class="govuk-table__cell lbh-table__cell--va-middle"
+              >
+                <a
+                  class="govuk-link"
+                  href="/workers/a"
+                  id="worker_a"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Worker A
+                </a>
+              </td>
+              <td
+                class="govuk-table__cell govuk-table__cell--numeric"
+              />
+            </tr>
+            <tr
+              class="govuk-table__row govuk-radios"
+            >
+              <td
+                class="govuk-table__cell"
+              >
+                <div
+                  class="govuk-radios__item"
+                >
+                  <input
+                    aria-labelledby="worker_b"
+                    class="govuk-radios__input"
+                    name="worker"
+                    type="radio"
+                    value="b"
+                  />
+                  <label
+                    class="govuk-label govuk-radios__label"
+                  />
+                </div>
+              </td>
+              <td
+                class="govuk-table__cell lbh-table__cell--va-middle"
+              >
+                <a
+                  class="govuk-link"
+                  href="/workers/b"
+                  id="worker_b"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Worker B
+                </a>
+              </td>
+              <td
+                class="govuk-table__cell govuk-table__cell--numeric"
+              />
+            </tr>
+            <tr
+              class="govuk-table__row govuk-radios"
+            >
+              <td
+                class="govuk-table__cell"
+              >
+                <div
+                  class="govuk-radios__item"
+                >
+                  <input
+                    aria-labelledby="worker_c"
+                    class="govuk-radios__input"
+                    name="worker"
+                    type="radio"
+                    value="c"
+                  />
+                  <label
+                    class="govuk-label govuk-radios__label"
+                  />
+                </div>
+              </td>
+              <td
+                class="govuk-table__cell lbh-table__cell--va-middle"
+              >
+                <a
+                  class="govuk-link"
+                  href="/workers/c"
+                  id="worker_c"
+                  rel="noopener"
+                  target="_blank"
+                >
+                  Worker C
+                </a>
+              </td>
+              <td
+                class="govuk-table__cell govuk-table__cell--numeric"
+              />
+            </tr>
+          </tbody>
+        </table>
+        <button
+          class="govuk-button"
+          data-module="govuk-button"
+          type="submit"
+        >
+          Allocate worker
+        </button>
+      </form>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/components/AllocatedWorkers/AllocatedWorker.spec.jsx
+++ b/components/AllocatedWorkers/AllocatedWorker.spec.jsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react';
+
+import UserContext from 'components/UserContext/UserContext';
+import AllocatedWorkers from './AllocatedWorkers';
+
+import { getAllocatedWorkers } from 'utils/api/allocatedWorkers';
+
+jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
+
+jest.mock('utils/api/allocatedWorkers', () => ({
+  getAllocatedWorkers: jest.fn(),
+}));
+
+jest.mock('components/AllocatedWorkers/AllocatedWorkersTable', () => () => (
+  <div>MockedAllocatedWorkersTable</div>
+));
+jest.mock(
+  'components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker',
+  () => () => <div>MockedAddAllocatedWorkers</div>
+);
+
+describe(`AddAllocatedWorker`, () => {
+  getAllocatedWorkers.mockImplementation(() =>
+    Promise.resolve({
+      allocations: [
+        { id: '1', name: 'Team 1' },
+        { id: '2', name: 'Team 2' },
+        { id: '3', name: 'Team 3' },
+      ],
+    })
+  );
+
+  const props = {
+    id: '123',
+  };
+
+  it('should render only the table if not admin', async () => {
+    const { findByText, queryByText } = render(
+      <UserContext.Provider
+        value={{
+          user: { name: 'foo', email: 'foo@bar.com' },
+        }}
+      >
+        <AllocatedWorkers {...props} type="people" />
+      </UserContext.Provider>
+    );
+    const allocateTable = await findByText('MockedAllocatedWorkersTable');
+    expect(allocateTable).toBeInTheDocument();
+    const addAllocate = await queryByText('MockedAddAllocatedWorkers');
+    expect(addAllocate).not.toBeInTheDocument();
+  });
+
+  it('should render everything if admin', async () => {
+    const { findByText, queryByText } = render(
+      <UserContext.Provider
+        value={{
+          user: {
+            name: 'foo',
+            email: 'foo@bar.com',
+            hasAdminPermissions: true,
+          },
+        }}
+      >
+        <AllocatedWorkers {...props} type="people" />
+      </UserContext.Provider>
+    );
+    const allocateTable = await findByText('MockedAllocatedWorkersTable');
+    expect(allocateTable).toBeInTheDocument();
+    const addAllocate = await queryByText('MockedAddAllocatedWorkers');
+    expect(addAllocate).toBeInTheDocument();
+  });
+});

--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import AllocatedWorkersTable from 'components/AllocatedWorkers/AllocatedWorkersTable';
+import AddAllocatedWorker from 'components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { getAllocatedWorkers } from 'utils/api/allocatedWorkers';
 import Spinner from 'components/Spinner/Spinner';
@@ -30,7 +31,15 @@ const AllocatedWorkers = ({ id }) => {
         </div>
       ) : (
         <>
-          {allocWorkers && <AllocatedWorkersTable records={allocWorkers} />}
+          {allocWorkers && (
+            <div className="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+              <AllocatedWorkersTable records={allocWorkers} />
+              <AddAllocatedWorker
+                personId={id}
+                currentlyAllocated={allocWorkers.length}
+              />
+            </div>
+          )}
           {error && <ErrorMessage />}
         </>
       )}

--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -10,7 +10,7 @@ import UserContext from 'components/UserContext/UserContext';
 
 const AllocatedWorkers = ({ id }) => {
   const [error, setError] = useState();
-  const [loading, setLoading] = useState();
+  const [loading, setLoading] = useState(true);
   const [allocWorkers, setAllocWorkers] = useState();
   const getWorkers = useCallback(async () => {
     try {
@@ -29,20 +29,16 @@ const AllocatedWorkers = ({ id }) => {
     return <Spinner />;
   }
   return (
-    <>
-      {allocWorkers && (
-        <div className="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
-          <AllocatedWorkersTable records={allocWorkers} />
-          {user.hasAdminPermissions && (
-            <AddAllocatedWorker
-              personId={id}
-              currentlyAllocated={allocWorkers.length}
-            />
-          )}
-        </div>
+    <div className="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+      {allocWorkers && <AllocatedWorkersTable records={allocWorkers} />}
+      {user.hasAdminPermissions && (
+        <AddAllocatedWorker
+          personId={id}
+          currentlyAllocated={allocWorkers.length}
+        />
       )}
       {error && <ErrorMessage />}
-    </>
+    </div>
   );
 };
 

--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import AllocatedWorkersTable from 'components/AllocatedWorkers/AllocatedWorkersTable';
@@ -6,6 +6,7 @@ import AddAllocatedWorker from 'components/AllocatedWorkers/AddAllocatedWorker/A
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { getAllocatedWorkers } from 'utils/api/allocatedWorkers';
 import Spinner from 'components/Spinner/Spinner';
+import UserContext from 'components/UserContext/UserContext';
 
 const AllocatedWorkers = ({ id }) => {
   const [error, setError] = useState();
@@ -23,26 +24,24 @@ const AllocatedWorkers = ({ id }) => {
   useEffect(() => {
     getWorkers();
   }, []);
+  const { user } = useContext(UserContext);
+  if (loading) {
+    return <Spinner />;
+  }
   return (
     <>
-      {loading ? (
-        <div>
-          <Spinner />
-        </div>
-      ) : (
-        <>
-          {allocWorkers && (
-            <div className="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
-              <AllocatedWorkersTable records={allocWorkers} />
-              <AddAllocatedWorker
-                personId={id}
-                currentlyAllocated={allocWorkers.length}
-              />
-            </div>
+      {allocWorkers && (
+        <div className="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
+          <AllocatedWorkersTable records={allocWorkers} />
+          {user.hasAdminPermissions && (
+            <AddAllocatedWorker
+              personId={id}
+              currentlyAllocated={allocWorkers.length}
+            />
           )}
-          {error && <ErrorMessage />}
-        </>
+        </div>
       )}
+      {error && <ErrorMessage />}
     </>
   );
 };

--- a/components/Modal/Modal.module.scss
+++ b/components/Modal/Modal.module.scss
@@ -1,7 +1,8 @@
 .modal {
   position: relative;
   width: 90%;
-  height: 80%;
+  max-width: 960px;
+  height: auto;
   margin: 0;
   padding: 2.5rem;
   background-color: #fff;

--- a/components/Modal/Modal.spec.jsx
+++ b/components/Modal/Modal.spec.jsx
@@ -2,8 +2,6 @@ import { render, fireEvent } from '@testing-library/react';
 
 import Modal from './Modal';
 
-jest.mock('components/Icons/TimesCircle', () => () => 'MockedCloseIcon');
-
 describe(`Modal`, () => {
   const props = {
     onRequestClose: jest.fn(),

--- a/components/Modal/__snapshots__/Modal.spec.jsx.snap
+++ b/components/Modal/__snapshots__/Modal.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`Modal should render properly 1`] = `
     <button
       class="closeButton"
     >
-      MockedCloseIcon
+      MockedCloseButton
     </button>
     <div>
       <p>

--- a/pages/api/residents/[id]/allocated-workers.js
+++ b/pages/api/residents/[id]/allocated-workers.js
@@ -1,6 +1,9 @@
 import * as HttpStatus from 'http-status-codes';
 
-import { getResidentAllocatedWorkers } from 'utils/server/allocatedWorkers';
+import {
+  getResidentAllocatedWorkers,
+  addAllocatedWorker,
+} from 'utils/server/allocatedWorkers';
 import { isAuthorised } from 'utils/auth';
 
 export default async (req, res) => {
@@ -29,17 +32,17 @@ export default async (req, res) => {
       }
       break;
 
-    // case 'POST':
-    //   try {
-    //     const data = await addAllocatedWorker(req.query.id, req.body);
-    //     res.status(HttpStatus.OK).json(data);
-    //   } catch (error) {
-    //     console.log('Allocated Workers post error:', error?.response?.data);
-    //     res
-    //       .status(HttpStatus.INTERNAL_SERVER_ERROR)
-    //       .json({ message: 'Unable to post Allocated Workers'});
-    //   }
-    //   break;
+    case 'POST':
+      try {
+        const data = await addAllocatedWorker(req.query.id, req.body);
+        res.status(HttpStatus.OK).json(data);
+      } catch (error) {
+        console.log('Allocated Workers post error:', error?.response?.data);
+        res
+          .status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .json({ message: 'Unable to post Allocated Workers' });
+      }
+      break;
 
     default:
       res

--- a/pages/api/teams/[team_id]/workers.js
+++ b/pages/api/teams/[team_id]/workers.js
@@ -1,0 +1,35 @@
+import * as HttpStatus from 'http-status-codes';
+
+import { getWorkers } from 'utils/server/workers';
+import { isAuthorised } from 'utils/auth';
+
+export default async (req, res) => {
+  const user = isAuthorised({ req });
+  if (!user) {
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
+  }
+  switch (req.method) {
+    case 'GET':
+      try {
+        const data = await getWorkers(req.query);
+        res.status(HttpStatus.OK).json(data);
+      } catch (error) {
+        console.log('Workers get error:', error?.response?.data);
+        error?.response?.status === HttpStatus.NOT_FOUND
+          ? res
+              .status(HttpStatus.NOT_FOUND)
+              .json({ message: 'Workers Not Found' })
+          : res
+              .status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .json({ message: 'Unable to get the Workers' });
+      }
+      break;
+
+    default:
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
+  }
+};

--- a/pages/api/teams/index.js
+++ b/pages/api/teams/index.js
@@ -1,0 +1,37 @@
+import * as HttpStatus from 'http-status-codes';
+
+import { getTeams } from 'utils/server/teams';
+import { isAuthorised } from 'utils/auth';
+
+export default async (req, res) => {
+  const user = isAuthorised({ req });
+  if (!user) {
+    return res
+      .status(HttpStatus.UNAUTHORIZED)
+      .json({ message: 'Auth cookie missing.' });
+  }
+  switch (req.method) {
+    case 'GET':
+      try {
+        const data = await getTeams({
+          context_flag: user.permissionFlag,
+        });
+        res.status(HttpStatus.OK).json(data);
+      } catch (error) {
+        console.log('Teams get error:', error?.response?.data);
+        error?.response?.status === HttpStatus.NOT_FOUND
+          ? res
+              .status(HttpStatus.NOT_FOUND)
+              .json({ message: 'Teams Not Found' })
+          : res
+              .status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .json({ message: 'Unable to get the Teams' });
+      }
+      break;
+
+    default:
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
+  }
+};

--- a/pages/api/teams/index.js
+++ b/pages/api/teams/index.js
@@ -14,7 +14,7 @@ export default async (req, res) => {
     case 'GET':
       try {
         const data = await getTeams({
-          context_flag: user.permissionFlag,
+          context_flag: user.permissionFlag || 'A', //TODO fix this once 'B' has been added to the BE
         });
         res.status(HttpStatus.OK).json(data);
       } catch (error) {

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -61,6 +61,13 @@ $screen-sm-min: 576px;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+  button {
+    margin-bottom: auto;
+  }
+}
+
+.lbh-table__cell--va-middle {
+  vertical-align: middle;
 }
 
 .cancel-icon {

--- a/utils/api/allocatedWorkers.js
+++ b/utils/api/allocatedWorkers.js
@@ -5,10 +5,20 @@ export const getAllocatedWorkers = async (id) => {
   return data;
 };
 
-export const addAllocatedWorkers = async (formData) => {
+export const addAllocatedWorker = async (residentId, body) => {
   const { data } = await axios.post(
-    `/api/residents/allocated-workers`,
-    formData
+    `/api/residents/${residentId}/allocated-workers`,
+    body
   );
+  return data;
+};
+
+export const getTeams = async () => {
+  const { data } = await axios.get(`/api/teams`);
+  return data;
+};
+
+export const getTeamWorkers = async (teamId) => {
+  const { data } = await axios.get(`/api/teams/${teamId}/workers`);
   return data;
 };

--- a/utils/api/allocatedWorkers.spec.js
+++ b/utils/api/allocatedWorkers.spec.js
@@ -16,4 +16,41 @@ describe('allocatedWorkers APIs', () => {
       expect(data).toEqual({ foo: 'bar' });
     });
   });
+
+  describe('addAllocatedWorker', () => {
+    it('should work properly', async () => {
+      axios.post.mockResolvedValue({ data: { foo: 'foobar' } });
+      const data = await allocatedWorkersAPI.addAllocatedWorker(123, {
+        foo: 'bar',
+      });
+      expect(axios.post).toHaveBeenCalled();
+      expect(axios.post.mock.calls[0][0]).toEqual(
+        '/api/residents/123/allocated-workers'
+      );
+      expect(axios.post.mock.calls[0][1]).toEqual({
+        foo: 'bar',
+      });
+      expect(data).toEqual({ foo: 'foobar' });
+    });
+  });
+
+  describe('getTeams', () => {
+    it('should work properly', async () => {
+      axios.get.mockResolvedValue({ data: { foo: 'bar' } });
+      const data = await allocatedWorkersAPI.getTeams();
+      expect(axios.get).toHaveBeenCalled();
+      expect(axios.get.mock.calls[0][0]).toEqual('/api/teams');
+      expect(data).toEqual({ foo: 'bar' });
+    });
+  });
+
+  describe('getTeamWorkers', () => {
+    it('should work properly', async () => {
+      axios.get.mockResolvedValue({ data: { foo: 'bar' } });
+      const data = await allocatedWorkersAPI.getTeamWorkers(123);
+      expect(axios.get).toHaveBeenCalled();
+      expect(axios.get.mock.calls[0][0]).toEqual('/api/teams/123/workers');
+      expect(data).toEqual({ foo: 'bar' });
+    });
+  });
 });

--- a/utils/server/allocatedWorkers.js
+++ b/utils/server/allocatedWorkers.js
@@ -10,9 +10,13 @@ export const getResidentAllocatedWorkers = async (mosaic_id, params) => {
   return data;
 };
 
-// export const addAllocatedWorkers = async (formData) => {
-//   const { data } = await axios.post(`${ENDPOINT_API}/allocations`, formData, {
-//     headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
-//   });
-//   return { ref: data?.['_id'] };
-// };
+export const addAllocatedWorker = async (resident_id, body) => {
+  const { data } = await axios.post(
+    `${ENDPOINT_API}/allocations`,
+    { resident_id, ...body },
+    {
+      headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
+    }
+  );
+  return data;
+};

--- a/utils/server/allocatedWorkers.spec.js
+++ b/utils/server/allocatedWorkers.spec.js
@@ -24,4 +24,26 @@ describe('allocatedWorkersAPI', () => {
       expect(data).toEqual({ allocations: 'hello' });
     });
   });
+
+  describe('addAllocatedWorker', () => {
+    it('should work properly', async () => {
+      axios.post.mockResolvedValue({ data: { foo: 'foobar' } });
+      const data = await allocatedWorkersAPI.addAllocatedWorker(123, {
+        foo: 'bar',
+      });
+      expect(axios.post).toHaveBeenCalled();
+      expect(axios.post.mock.calls[0][0]).toEqual(
+        `${ENDPOINT_API}/allocations`
+      );
+      expect(axios.post.mock.calls[0][1]).toEqual({
+        resident_id: 123,
+        foo: 'bar',
+      });
+      expect(axios.post.mock.calls[0][2].headers).toEqual({
+        'Content-Type': 'application/json',
+        'x-api-key': AWS_KEY,
+      });
+      expect(data).toEqual({ foo: 'foobar' });
+    });
+  });
 });

--- a/utils/server/teams.js
+++ b/utils/server/teams.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const { ENDPOINT_API, AWS_KEY } = process.env;
+
+const headersWithKey = {
+  'x-api-key': AWS_KEY,
+};
+
+export const getTeams = async (params) => {
+  const { data } = await axios.get(`${ENDPOINT_API}/teams`, {
+    headers: headersWithKey,
+    params,
+  });
+  return data;
+};

--- a/utils/server/teams.spec.js
+++ b/utils/server/teams.spec.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+import * as teamsAPI from './teams';
+
+jest.mock('axios');
+
+const { ENDPOINT_API, AWS_KEY } = process.env;
+
+describe('teams APIs', () => {
+  describe('getTeams', () => {
+    it('should work properly', async () => {
+      axios.get.mockResolvedValue({ data: { foo: 123, teams: 'bar' } });
+      const data = await teamsAPI.getTeams({
+        foo: 'bar',
+      });
+      expect(axios.get).toHaveBeenCalled();
+      expect(axios.get.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/teams`);
+      expect(axios.get.mock.calls[0][1].headers).toEqual({
+        'x-api-key': AWS_KEY,
+      });
+      expect(axios.get.mock.calls[0][1].params).toEqual({
+        foo: 'bar',
+      });
+      expect(data).toEqual({ foo: 123, teams: 'bar' });
+    });
+  });
+});

--- a/utils/server/workers.js
+++ b/utils/server/workers.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const { ENDPOINT_API, AWS_KEY } = process.env;
+
+const headersWithKey = {
+  'x-api-key': AWS_KEY,
+};
+
+export const getWorkers = async (params) => {
+  const { data } = await axios.get(`${ENDPOINT_API}/workers`, {
+    headers: headersWithKey,
+    params,
+  });
+  return data;
+};

--- a/utils/server/workers.spec.js
+++ b/utils/server/workers.spec.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+import * as workersAPI from './workers';
+
+jest.mock('axios');
+
+const { ENDPOINT_API, AWS_KEY } = process.env;
+
+describe('workers APIs', () => {
+  describe('getWorkers', () => {
+    it('should work properly', async () => {
+      axios.get.mockResolvedValue({ data: { foo: 123, workers: 'bar' } });
+      const data = await workersAPI.getWorkers({
+        foo: 'bar',
+      });
+      expect(axios.get).toHaveBeenCalled();
+      expect(axios.get.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/workers`);
+      expect(axios.get.mock.calls[0][1].headers).toEqual({
+        'x-api-key': AWS_KEY,
+      });
+      expect(axios.get.mock.calls[0][1].params).toEqual({
+        foo: 'bar',
+      });
+      expect(data).toEqual({ foo: 123, workers: 'bar' });
+    });
+  });
+});


### PR DESCRIPTION
**What**  
- Added functionality for **allocate workers**
- Added the following endpoints
	- `/api/teams`
	- `/api/teams/:teamId/workers`
	- `POST /api/residents/:residentId/allocated-workers`
- Improved look&feel of the modal
- Improved `react-modal` mock

**Notes**
- the `POST` API is not there yet
- at the moment is only visible for Admin users (the proper user group is going to be introduced by #121)

<img width="1064" alt="Screenshot 2021-01-12 at 18 42 12" src="https://user-images.githubusercontent.com/435399/104358627-0152b500-550f-11eb-9656-a3f224ce4555.png">

<img width="1001" alt="Screenshot 2021-01-12 at 18 42 02" src="https://user-images.githubusercontent.com/435399/104358587-f1d36c00-550e-11eb-962c-a707a8753dd0.png">

<img width="1004" alt="Screenshot 2021-01-12 at 18 42 41" src="https://user-images.githubusercontent.com/435399/104358600-f7c94d00-550e-11eb-8683-c49ba880462f.png">
