### PR TITLE
Centralized the search around the router query

### DIFF
--- a/components/Search/Search.spec.jsx
+++ b/components/Search/Search.spec.jsx
@@ -1,15 +1,10 @@
 import { act, fireEvent, render } from '@testing-library/react';
 
+import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import UserContext from 'components/UserContext/UserContext';
-import Search from './Search';
-
 import { getResidents } from 'utils/api/residents';
 
-jest.mock('next/router', () => ({
-  useRouter: () => ({
-    replace: jest.fn(),
-  }),
-}));
+import Search from './Search';
 
 jest.mock('utils/api/residents', () => ({
   getResidents: jest.fn(),
@@ -18,7 +13,6 @@ jest.mock('utils/api/residents', () => ({
 describe(`Search`, () => {
   const props = {
     onFormSubmit: jest.fn(),
-    query: {},
   };
 
   it('should work properly on search success', async () => {
@@ -34,24 +28,26 @@ describe(`Search`, () => {
         ],
       })
     );
-    const { getByRole, getByLabelText, queryByText } = render(
-      <UserContext.Provider
-        value={{
-          user: { name: 'foo' },
-        }}
+    const { queryByText, findByText } = render(
+      <RouterContext.Provider
+        value={{ query: { foo: 'bar' }, replace: jest.fn() }}
       >
-        <Search {...props} type="people" />
-      </UserContext.Provider>
+        <UserContext.Provider
+          value={{
+            user: { name: 'foo' },
+          }}
+        >
+          <Search {...props} type="people" />
+        </UserContext.Provider>
+      </RouterContext.Provider>
     );
-    const firstNameInput = getByLabelText('First name:');
-    fireEvent.change(firstNameInput, { target: { value: 'foo' } });
-    expect(queryByText('Add New Person')).not.toBeInTheDocument();
-    await act(async () => {
-      fireEvent.submit(getByRole('form'));
-    });
+    const searchResult = await findByText('PEOPLE SEARCH RESULT');
+    expect(searchResult).toBeInTheDocument();
     // expect(queryByText('Add New Person')).toBeInTheDocument();
-    expect(queryByText('PEOPLE SEARCH RESULT')).toBeInTheDocument();
     expect(queryByText('load more')).not.toBeInTheDocument();
+  });
+
+  it('should work properly on search success - with cursor', async () => {
     getResidents.mockImplementation(() =>
       Promise.resolve({
         residents: [
@@ -65,29 +61,74 @@ describe(`Search`, () => {
         nextCursor: 'foo',
       })
     );
+    const { queryByText, findByText } = render(
+      <RouterContext.Provider
+        value={{ query: { foo: 'bar' }, replace: jest.fn() }}
+      >
+        <UserContext.Provider
+          value={{
+            user: { name: 'foo' },
+          }}
+        >
+          <Search {...props} type="people" />
+        </UserContext.Provider>
+      </RouterContext.Provider>
+    );
+    const searchResult = await findByText('PEOPLE SEARCH RESULT');
+    expect(searchResult).toBeInTheDocument();
+    expect(queryByText('load more')).toBeInTheDocument();
+  });
+
+  it('should update the queryString on search', async () => {
+    const mockOnReplace = jest.fn();
+    const { queryByText, getByLabelText, getByRole } = render(
+      <RouterContext.Provider
+        value={{
+          query: { foo: 'bar' },
+          pathname: 'foopath',
+          replace: mockOnReplace,
+        }}
+      >
+        <UserContext.Provider
+          value={{
+            user: { name: 'foo' },
+          }}
+        >
+          <Search {...props} type="people" />
+        </UserContext.Provider>
+      </RouterContext.Provider>
+    );
+    const firstNameInput = getByLabelText('First name:');
+    fireEvent.change(firstNameInput, { target: { value: 'foo' } });
+    expect(queryByText('Add New Person')).not.toBeInTheDocument();
     await act(async () => {
       fireEvent.submit(getByRole('form'));
     });
-    expect(queryByText('load more')).toBeInTheDocument();
+    expect(mockOnReplace).toHaveBeenCalled();
+    expect(mockOnReplace).toHaveBeenCalledWith(
+      'foopath?foo=bar&first_name=foo',
+      'foopath?foo=bar&first_name=foo',
+      { shallow: true }
+    );
   });
 
   it('should work properly on search fails', async () => {
     getResidents.mockImplementation(() => Promise.reject());
-    const { getByRole, getByLabelText, queryByText } = render(
-      <UserContext.Provider
-        value={{
-          user: { name: 'foo' },
-        }}
+    const { findByText } = render(
+      <RouterContext.Provider
+        value={{ query: { foo: 'bar' }, replace: jest.fn() }}
       >
-        <Search {...props} type="people" />
-      </UserContext.Provider>
+        <UserContext.Provider
+          value={{
+            user: { name: 'foo' },
+          }}
+        >
+          <Search {...props} type="people" />
+        </UserContext.Provider>
+      </RouterContext.Provider>
     );
-    const firstNameInput = getByLabelText('First name:');
-    fireEvent.change(firstNameInput, { target: { value: 'foo' } });
-    await act(async () => {
-      fireEvent.submit(getByRole('form'));
-    });
+    const errorLabel = await findByText('Oops an error occurred');
+    expect(errorLabel).toBeInTheDocument();
     // expect(queryByText('Add New Person')).toBeInTheDocument();
-    expect(queryByText('Oops an error occurred')).toBeInTheDocument();
   });
 });

--- a/components/Search/forms/SearchCasesForm.jsx
+++ b/components/Search/forms/SearchCasesForm.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
 import isPast from 'date-fns/isPast';
@@ -14,7 +13,7 @@ import {
 } from 'components/Form';
 import FORM_NAMES from 'data/formNames';
 
-const SearchCasesForm = ({ onFormSubmit, query }) => {
+const SearchCasesForm = ({ onFormSubmit, defaultValues }) => {
   const {
     register,
     errors,
@@ -22,11 +21,8 @@ const SearchCasesForm = ({ onFormSubmit, query }) => {
     handleSubmit,
     formState: { isDirty },
   } = useForm({
-    defaultValues: query,
+    defaultValues,
   });
-  useEffect(() => {
-    Object.keys(query).length && onFormSubmit(query);
-  }, []);
   return (
     <form role="form" onSubmit={handleSubmit((data) => onFormSubmit(data))}>
       <div className="govuk-grid-row">
@@ -135,7 +131,7 @@ const SearchCasesForm = ({ onFormSubmit, query }) => {
 
 SearchCasesForm.propTypes = {
   onFormSubmit: PropTypes.func.isRequired,
-  query: PropTypes.shape({}),
+  defaultValues: PropTypes.shape({}),
 };
 
 export default SearchCasesForm;

--- a/components/Search/forms/SearchCasesForm.spec.jsx
+++ b/components/Search/forms/SearchCasesForm.spec.jsx
@@ -11,7 +11,7 @@ import SearchCasesForm from './SearchCasesForm';
 describe(`SearchCasesForm`, () => {
   const props = {
     onFormSubmit: jest.fn(),
-    query: {},
+    defaultValues: {},
     user: {
       name: 'i am a user',
     },
@@ -59,9 +59,9 @@ describe(`SearchCasesForm`, () => {
     });
   });
 
-  it('should initialise the form with the passed query', async () => {
+  it('should initialise the form with the passed defaultValues', async () => {
     const { getByRole } = render(
-      <SearchCasesForm {...props} query={{ first_name: 'bar' }} />
+      <SearchCasesForm {...props} defaultValues={{ first_name: 'bar' }} />
     );
     await act(async () => {
       fireEvent.submit(getByRole('form'));

--- a/components/Search/forms/SearchResidentsForm.jsx
+++ b/components/Search/forms/SearchResidentsForm.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
 import isPast from 'date-fns/isPast';
@@ -6,7 +5,7 @@ import isPostcodeValid from 'uk-postcode-validator';
 
 import { Button, TextInput, DateInput } from 'components/Form';
 
-const SearchResidentsForm = ({ onFormSubmit, query }) => {
+const SearchResidentsForm = ({ onFormSubmit, defaultValues }) => {
   const {
     register,
     errors,
@@ -14,11 +13,8 @@ const SearchResidentsForm = ({ onFormSubmit, query }) => {
     handleSubmit,
     formState: { isDirty },
   } = useForm({
-    defaultValues: query,
+    defaultValues,
   });
-  useEffect(() => {
-    Object.keys(query).length && onFormSubmit(query);
-  }, []);
   return (
     <form role="form" onSubmit={handleSubmit((data) => onFormSubmit(data))}>
       <div className="govuk-grid-row">
@@ -98,7 +94,7 @@ const SearchResidentsForm = ({ onFormSubmit, query }) => {
 
 SearchResidentsForm.propTypes = {
   onFormSubmit: PropTypes.func.isRequired,
-  query: PropTypes.shape({}),
+  defaultValues: PropTypes.shape({}),
 };
 
 export default SearchResidentsForm;

--- a/components/Search/forms/SearchResidentsForm.spec.jsx
+++ b/components/Search/forms/SearchResidentsForm.spec.jsx
@@ -11,7 +11,7 @@ import SearchResidentsForm from './SearchResidentsForm';
 describe(`SearchResidentsForm`, () => {
   const props = {
     onFormSubmit: jest.fn(),
-    query: {},
+    defaultValues: {},
   };
 
   it('should pass to onFormSubmit the form values', async () => {
@@ -33,9 +33,9 @@ describe(`SearchResidentsForm`, () => {
     });
   });
 
-  it('should initialise the form with the passed query', async () => {
+  it('should initialise the form with the passed defaultValues', async () => {
     const { getByRole } = render(
-      <SearchResidentsForm {...props} query={{ first_name: 'bar' }} />
+      <SearchResidentsForm {...props} defaultValues={{ first_name: 'bar' }} />
     );
     await act(async () => {
       fireEvent.submit(getByRole('form'));

--- a/pages/cases/index.jsx
+++ b/pages/cases/index.jsx
@@ -2,21 +2,18 @@ import { NextSeo } from 'next-seo';
 
 import Search from 'components/Search/Search';
 
-const SearchCasesPage = ({ query }) => {
+const SearchCasesPage = () => {
   return (
     <div>
       <NextSeo title="Find unlinked case notes" noindex />
-      <Search query={query} type="records" />
+      <Search type="records" />
     </div>
   );
 };
 
-export const getServerSideProps = async (ctx) => {
-  const { query } = ctx;
+export const getServerSideProps = async () => {
   return {
-    props: {
-      query,
-    },
+    props: {},
   };
 };
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -2,21 +2,18 @@ import { NextSeo } from 'next-seo';
 
 import Search from 'components/Search/Search';
 
-const SearchResidentPage = ({ query }) => {
+const SearchResidentPage = () => {
   return (
     <div>
       <NextSeo title="Search" noindex />
-      <Search query={query} type="people" />
+      <Search type="people" />
     </div>
   );
 };
 
-export const getServerSideProps = async (ctx) => {
-  const { query } = ctx;
+export const getServerSideProps = async () => {
   return {
-    props: {
-      query,
-    },
+    props: {},
   };
 };
 

--- a/utils/urls.js
+++ b/utils/urls.js
@@ -28,3 +28,9 @@ export const getQueryString = (obj) =>
         : acc,
     ''
   );
+
+export const parseQueryString = (str) =>
+  str?.split('&')?.reduce((acc, curr) => {
+    const [key, value] = curr.split('=');
+    return { ...acc, [key]: value };
+  }, {}) || {};

--- a/utils/urls.spec.js
+++ b/utils/urls.spec.js
@@ -1,4 +1,4 @@
-import { getQueryString } from './urls';
+import { getQueryString, parseQueryString } from './urls';
 
 describe('urls', () => {
   describe('getQueryStrin', () => {
@@ -16,6 +16,20 @@ describe('urls', () => {
           yo: true,
         })
       ).toEqual('foo=123&barfoo=yo&yo=true');
+    });
+  });
+
+  describe('parseQueryString', () => {
+    it('should return empty string on empty object', () => {
+      expect(parseQueryString('')).toEqual({});
+    });
+
+    it('should return the proper string filtering empty values', () => {
+      expect(parseQueryString('foo=123&barfoo=yo&yo=true')).toEqual({
+        foo: '123',
+        barfoo: 'yo',
+        yo: 'true',
+      });
     });
   });
 });


### PR DESCRIPTION
**What**  
- removed `useEffect` from the search forms, centralized it in the parent search component
- form search and sort are using the same logic
- merged the `sort` and the `query` object
- not need to store in the component `formData` and `sort`
- not need to populate the query server side

**How to test it?**
Everything should work as before