### PR TITLE
fixed problem with fewer hooks rendered

### DIFF
--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
@@ -48,9 +48,6 @@ const AddAllocatedWorker = ({ personId, currentlyAllocated }) => {
   useEffect(() => {
     selectedTeam && getAllocatedWorkers();
   }, [selectedTeam]);
-  if (error) {
-    return 'Oops an error occurred';
-  }
   const closeModal = useCallback(() => {
     setIsModalOpen(false);
     setWorkers();
@@ -66,6 +63,9 @@ const AddAllocatedWorker = ({ personId, currentlyAllocated }) => {
     }
     setPostLoading(false);
   });
+  if (error) {
+    return 'Oops an error occurred';
+  }
   return (
     <>
       <div className="lbh-table-header">


### PR DESCRIPTION
**What**  
In case of API failing it was rendering fewer hooks breaking the page.

See more details [here](https://reactjs.org/docs/error-decoder.html/?invariant=300).