### PR TITLE
fixed saving functionality

### DIFF
--- a/components/DynamicStep/DynamicStep.jsx
+++ b/components/DynamicStep/DynamicStep.jsx
@@ -61,7 +61,7 @@ const DynamicStep = ({
             isSecondary
             label="Save and Exit"
             type="button"
-            onClick={handleSubmit(onSaveAndExit)}
+            onClick={() => onSaveAndExit(stepValues)}
           />
         </div>
       </form>


### PR DESCRIPTION
**What**  
Decoupled **Save and Exit** from the form submission. Now it's possible to save uncompleted forms (even if they are not valid) this is making the save functionality useful also for single-page forms.

**How to test it**
- go to http://localhost:3000/form/test/first-step
- select *show next step*
- then *save and exit*
- check that is working properly