### PR TITLE
used hasAllocationsPermissions instead of hasAdminPermissions

### DIFF
--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -31,7 +31,7 @@ const AllocatedWorkers = ({ id }) => {
   return (
     <div className="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
       {allocWorkers && <AllocatedWorkersTable records={allocWorkers} />}
-      {user.hasAdminPermissions && (
+      {user.hasAllocationsPermissions && (
         <AddAllocatedWorker
           personId={id}
           currentlyAllocated={allocWorkers.length}

--- a/components/AllocatedWorkers/AllocatedWorkers.spec.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.spec.jsx
@@ -57,7 +57,7 @@ describe(`AddAllocatedWorker`, () => {
           user: {
             name: 'foo',
             email: 'foo@bar.com',
-            hasAdminPermissions: true,
+            hasAllocationsPermissions: true,
           },
         }}
       >

--- a/components/AllocatedWorkers/AllocatedWorkersTable.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkersTable.jsx
@@ -22,7 +22,7 @@ const AllocatedWorkersEntry = ({
         <h3 className="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0">
           Allocated Worker {index + 1}
         </h3>
-        {user.hasAdminPermissions && (
+        {user.hasAllocationsPermissions && (
           <Button isSecondary label="Deallocate Worker" onClick={openModal} />
         )}
       </div>

--- a/components/AllocatedWorkers/AllocatedWorkersTable.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkersTable.jsx
@@ -96,11 +96,11 @@ const AllocatedWorkersTable = ({ records, personName }) => {
 AllocatedWorkersTable.propTypes = {
   records: PropTypes.arrayOf(
     PropTypes.shape({
-      allocatedWorker: PropTypes.string,
-      role: PropTypes.string,
-      allocatedTeam: PropTypes.string,
-      startDate: PropTypes.number,
-      endDate: PropTypes.number,
+      allocatedWorkerTeam: PropTypes.string.isRequired,
+      allocatedWorker: PropTypes.string.isRequired,
+      allocationStartDate: PropTypes.string.isRequired,
+      allocationEndDate: PropTypes.string,
+      workerType: PropTypes.string.isRequired,
     })
   ).isRequired,
 };


### PR DESCRIPTION
**What**  
- Used `hasAllocationsPermissions` for show/hide allocation interactions
- Fixed propTypes in `AllocatedWorkerTable` component
- Fixed spec filename