### PR TITLE
fixed modal scrolling

### DIFF
--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
@@ -19,6 +19,7 @@ const AddAllocatedWorker = ({
   onAddNewAllocation,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [workersLoading, setWorkersLoading] = useState(false);
   const [teams, setTeams] = useState();
   const [workers, setWorkers] = useState();
   const [error, setError] = useState();
@@ -41,13 +42,14 @@ const AddAllocatedWorker = ({
   }, []);
   const selectedTeam = watch('team');
   const getAllocatedWorkers = useCallback(async () => {
-    setWorkers();
+    setWorkersLoading(true);
     try {
       const data = await getTeamWorkers(selectedTeam);
       setWorkers(data.workers);
     } catch (e) {
       setError(true);
     }
+    setWorkersLoading();
   });
   useEffect(() => {
     selectedTeam && getAllocatedWorkers();
@@ -150,6 +152,7 @@ const AddAllocatedWorker = ({
                                   name="worker"
                                   type="radio"
                                   value={id}
+                                  disabled={workersLoading}
                                   ref={register}
                                 />
                                 <label className="govuk-label govuk-radios__label"></label>

--- a/components/Modal/Modal.jsx
+++ b/components/Modal/Modal.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
 
@@ -7,20 +8,26 @@ import style from './Modal.module.scss';
 
 ReactModal.setAppElement('#root');
 
-const Modal = ({ isOpen, onRequestClose, children }) => (
-  <ReactModal
-    isOpen={isOpen}
-    onRequestClose={onRequestClose}
-    className={style.modal}
-    overlayClassName={style.backdrop}
-    shouldCloseOnOverlayClick
-  >
-    <button className={style.closeButton} onClick={onRequestClose}>
-      <TimesCircleIcon color="border" />
-    </button>
-    <div>{children}</div>
-  </ReactModal>
-);
+const Modal = ({ isOpen, onRequestClose, children }) => {
+  useEffect(() => {
+    document.documentElement.style.overflow = isOpen ? 'hidden' : '';
+    return () => (document.documentElement.style.overflow = '');
+  }, [isOpen]);
+  return (
+    <ReactModal
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      className={style.modal}
+      overlayClassName={style.backdrop}
+      shouldCloseOnOverlayClick
+    >
+      <button className={style.closeButton} onClick={onRequestClose}>
+        <TimesCircleIcon color="border" />
+      </button>
+      <div>{children}</div>
+    </ReactModal>
+  );
+};
 
 Modal.propTypes = {
   isOpen: PropTypes.bool.isRequired,

--- a/components/Modal/Modal.module.scss
+++ b/components/Modal/Modal.module.scss
@@ -1,10 +1,8 @@
 .modal {
-  position: relative;
+  position: absolute;
   width: 90%;
   max-width: 960px;
-  height: auto;
   margin: 0;
-  padding: 2.5rem;
   background-color: #fff;
   border-radius: 0.3rem;
   box-shadow: 0 0 2.5rem rgba(0, 0, 0, 0.5);
@@ -13,8 +11,9 @@
   text-align: left;
   transform: translate(-50%, -50%);
   & > div {
-    overflow-y: auto;
-    height: 100%;
+    padding: 2.5rem;
+    overflow: auto;
+    max-height: 90vh;
   }
 }
 

--- a/components/Modal/Modal.spec.jsx
+++ b/components/Modal/Modal.spec.jsx
@@ -23,4 +23,12 @@ describe(`Modal`, () => {
     fireEvent.click(getByRole('button'));
     expect(props.onRequestClose).toHaveBeenCalled();
   });
+
+  it('should set overflow hidden on the body once open', () => {
+    expect(document.documentElement.style.overflow).not.toBe('hidden');
+    const { unmount } = render(<Modal {...props} />);
+    expect(document.documentElement.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.documentElement.style.overflow).not.toBe('hidden');
+  });
 });

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -77,3 +77,7 @@ $screen-sm-min: 576px;
   position: relative;
   cursor: pointer;
 }
+
+.ReactModal__Body--open {
+  overflow: hidden;
+}


### PR DESCRIPTION
**What**  
- fixed modal scrolling (when the content of the modal is bigger than view height)
- prevent scroll of the body, behind the modal
- in `AddAllocatedWorkers` fixed jump when loading a different team, setting the current workers as `disabled`

The `govuk` library is setting 
```
.govuk-template {
    overflow-y: scroll;
}
```
on the `html`, as I am not sure of the reason behind it I am setting the `overflow` of the `html` to `hidden` when the modal is open.