### PR TITLE
made the DateInput component uncrontrolled

### DIFF
--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -70,7 +70,7 @@ const DateInput = forwardRef(
                   id={`${name}-day`}
                   name={`${name}-day`}
                   type="text"
-                  pattern="^\d{1,2}$"
+                  pattern="^\d{2}$"
                   inputMode="numeric"
                   defaultValue={date.day}
                   onChange={({ target: { value } }) =>
@@ -99,7 +99,7 @@ const DateInput = forwardRef(
                   id={`${name}-month`}
                   name={`${name}-month`}
                   type="text"
-                  pattern="^\d{1,2}$"
+                  pattern="^\d{2}$"
                   inputMode="numeric"
                   defaultValue={date.month}
                   onChange={({ target: { value } }) =>

--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -1,18 +1,15 @@
-import { useState, useEffect, forwardRef } from 'react';
+import { useCallback, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Controller } from 'react-hook-form';
-import isValid from 'date-fns/isValid';
 
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
-import { convertFormat } from 'utils/date';
-
-const getInitialDate = (value, format) => {
-  const date = value?.split('-') || ['', '', ''];
-  return format === 'US'
-    ? { day: date[2], month: date[1], year: date[0] }
-    : { day: date[0], month: date[1], year: date[2] };
-};
+import {
+  convertFormat,
+  isDateValid,
+  stringDateToObject,
+  objectDateToString,
+} from 'utils/date';
 
 const DateInput = forwardRef(
   (
@@ -30,19 +27,10 @@ const DateInput = forwardRef(
     },
     ref
   ) => {
-    const [date, setDate] = useState(getInitialDate(value, format));
-    useEffect(() => {
-      const { day, month, year } = date;
-      day !== '' &&
-        month !== '' &&
-        year !== '' &&
-        onChange(
-          format === 'US'
-            ? `${year}-${month}-${day}`
-            : `${day}-${month}-${year}`
-        );
-      day === '' && month === '' && year === '' && onChange();
-    }, [date]);
+    const date = stringDateToObject(value, format);
+    const setNewDate = useCallback((newDate) =>
+      onChange(objectDateToString({ ...date, ...newDate }))
+    );
     return (
       <div
         className={cx('govuk-form-group', {
@@ -84,9 +72,9 @@ const DateInput = forwardRef(
                   type="text"
                   pattern="^\d{1,2}$"
                   inputMode="numeric"
-                  value={date.day}
+                  defaultValue={date.day}
                   onChange={({ target: { value } }) =>
-                    setDate({ ...date, day: value })
+                    setNewDate({ day: value })
                   }
                   ref={ref}
                   {...otherProps}
@@ -113,9 +101,9 @@ const DateInput = forwardRef(
                   type="text"
                   pattern="^\d{1,2}$"
                   inputMode="numeric"
-                  value={date.month}
+                  defaultValue={date.month}
                   onChange={({ target: { value } }) =>
-                    setDate({ ...date, month: value })
+                    setNewDate({ month: value })
                   }
                   {...otherProps}
                 />
@@ -141,9 +129,9 @@ const DateInput = forwardRef(
                   type="text"
                   pattern="^\d{4}$"
                   inputMode="numeric"
-                  value={date.year}
+                  defaultValue={date.year}
                   onChange={({ target: { value } }) =>
-                    setDate({ ...date, year: value })
+                    setNewDate({ year: value })
                   }
                   {...otherProps}
                 />
@@ -173,20 +161,19 @@ const ControlledDateInput = ({
 }) => (
   <Controller
     as={<DateInput format={format} {...otherProps} />}
-    onChange={([value]) => value}
     name={name}
     rules={{
       ...rules,
       validate: {
         valid: (value) =>
           value &&
-          (isValid(new Date(format === 'US' ? value : convertFormat(value))) ||
+          (isDateValid(format === 'US' ? value : convertFormat(value)) ||
             'Must be a is valid Date'),
         ...rules?.validate,
       },
     }}
     control={control}
-    defaultValue={control.defaultValuesRef.current[name] || null}
+    defaultValue={null}
   />
 );
 

--- a/components/Search/forms/SearchCasesForm.spec.jsx
+++ b/components/Search/forms/SearchCasesForm.spec.jsx
@@ -36,6 +36,8 @@ describe(`SearchCasesForm`, () => {
       form_name: '',
       exact_name_match: false,
       my_notes_only: false,
+      end_date: null,
+      start_date: null,
     });
   });
 
@@ -56,6 +58,8 @@ describe(`SearchCasesForm`, () => {
       form_name: '',
       exact_name_match: false,
       my_notes_only: true,
+      end_date: null,
+      start_date: null,
     });
   });
 
@@ -72,6 +76,8 @@ describe(`SearchCasesForm`, () => {
       form_name: '',
       exact_name_match: false,
       my_notes_only: false,
+      end_date: null,
+      start_date: null,
     });
   });
 });

--- a/components/Search/forms/SearchResidentsForm.spec.jsx
+++ b/components/Search/forms/SearchResidentsForm.spec.jsx
@@ -30,6 +30,7 @@ describe(`SearchResidentsForm`, () => {
       last_name: '',
       mosaic_id: '',
       postcode: '',
+      date_of_birth: null,
     });
   });
 
@@ -45,6 +46,7 @@ describe(`SearchResidentsForm`, () => {
       last_name: '',
       mosaic_id: '',
       postcode: '',
+      date_of_birth: null,
     });
   });
 });

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,7 +1,7 @@
 import isValid from 'date-fns/isValid';
 
 export const parseDate = (date) => {
-  const split = date.split(/[/-\s]/);
+  const split = date.split(/[/-\s]/).map((digit) => parseInt(digit, 10));
   return new Date(split[2], split[1] - 1, split[0]);
 };
 
@@ -18,3 +18,20 @@ export const convertFormat = (date) => {
   const values = date.split('-');
   return `${values[2]}-${values[1]}-${values[0]}`;
 };
+
+export const stringDateToObject = (value, format = 'US') => {
+  const date = value?.split('-') || ['', '', ''];
+  return format === 'US'
+    ? { day: date[2], month: date[1], year: date[0] }
+    : { day: date[0], month: date[1], year: date[2] };
+};
+
+export const objectDateToString = (
+  { day = '', month = '', year = '' },
+  format = 'US'
+) =>
+  day === '' && month === '' && year === ''
+    ? null
+    : format === 'US'
+    ? `${year}-${month}-${day}`
+    : `${day}-${month}-${year}`;

--- a/utils/date.spec.js
+++ b/utils/date.spec.js
@@ -1,4 +1,11 @@
-import { parseDate, formatDate, isDateValid, convertFormat } from './date';
+import {
+  parseDate,
+  formatDate,
+  isDateValid,
+  convertFormat,
+  stringDateToObject,
+  objectDateToString,
+} from './date';
 
 describe('date util', () => {
   describe('parseDate', () => {
@@ -19,12 +26,62 @@ describe('date util', () => {
       expect(isDateValid('22/09/1941')).toBe(true);
       expect(isDateValid('foo')).toBe(false);
       expect(isDateValid(null)).toBe(false);
+      expect(isDateValid('-12-12')).toBe(false);
     });
   });
 
   describe('convertFormat', () => {
     it('should work properly', () => {
       expect(convertFormat('2000-12-01')).toBe('01-12-2000');
+    });
+  });
+
+  describe('stringDateToObject', () => {
+    it('should work properly', () => {
+      expect(stringDateToObject('2000-12-01')).toEqual({
+        day: '01',
+        month: '12',
+        year: '2000',
+      });
+      expect(stringDateToObject('01-12-2000', 'EU')).toEqual({
+        day: '01',
+        month: '12',
+        year: '2000',
+      });
+      expect(stringDateToObject(null)).toEqual({
+        day: '',
+        month: '',
+        year: '',
+      });
+    });
+  });
+
+  describe('objectDateToString', () => {
+    it('should work properly', () => {
+      expect(
+        objectDateToString({
+          day: '01',
+          month: '12',
+          year: '2000',
+        })
+      ).toEqual('2000-12-01');
+      expect(
+        objectDateToString(
+          {
+            day: '01',
+            month: '12',
+            year: '2000',
+          },
+          'EU'
+        )
+      ).toEqual('01-12-2000');
+      expect(
+        objectDateToString({
+          day: '',
+          month: '',
+          year: '',
+        })
+      ).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
**What**  
- made the `DateInput` component (used by the `ControlledDateInput`) uncontrolled, this is making the component resettable and it's avoiding a bunch of conflicts related to the control of the inputs
- moved out `stringDateToObject` and `objectDateToString` and added to the `utils/date`
- improved `parseDate` util
- check that the _day_ and _month_ are two digits, as 1 digit is not returning any result

**How to test it**
Please double-check that the component is working as expected