### PR TITLE
added bodyParser to the /api route

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -2,13 +2,16 @@ const server = require('restana')();
 const app = require('next')({ dev: false });
 const files = require('serve-static');
 const path = require('path');
+const bodyParser = require('body-parser');
 const nextRequestHandler = app.getRequestHandler();
 
 server.use(files(path.join(__dirname, 'build')));
 server.use(files(path.join(__dirname, 'public')));
 
 // api routes, auth is handled by the authorizer
-server.all('/api/*', (req, res) => nextRequestHandler(req, res));
+server.all('/api/*', bodyParser.json(), (req, res) =>
+  nextRequestHandler(req, res)
+);
 
 server.all('*', (req, res) => nextRequestHandler(req, res));
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "body-parser": "^1.19.0",
     "cookie": "^0.4.1",
     "date-fns": "^2.16.1",
     "deepmerge": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,7 +3933,7 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
**What**  
The lambda is returning the `body` as a Buffer, as we added validation for `POST` the validator is failing if we don't have a valid object.

This PR is fixing that problem.