### PR TITLE
added support for dynamic options prop

### DIFF
--- a/components/FormWizard/DynamicInput.jsx
+++ b/components/FormWizard/DynamicInput.jsx
@@ -7,10 +7,12 @@ const DynamicInput = (props) => {
     component,
     register,
     control,
+    errors,
     id,
     name,
-    errors,
     multiStepIndex,
+    options,
+    currentData,
     ...otherProps
   } = props;
   const inputName =
@@ -22,6 +24,7 @@ const DynamicInput = (props) => {
     name: inputName,
     error: errors[inputName],
     required: otherProps?.rules?.required,
+    options: typeof options === 'function' ? options(currentData) : options,
     ...otherProps,
   };
   switch (component) {
@@ -44,6 +47,7 @@ DynamicInput.propTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   errors: PropTypes.object.isRequired,
+  currentData: PropTypes.object.isRequired,
   rules: PropTypes.shape({
     required: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   }),

--- a/components/FormWizard/DynamicStep.jsx
+++ b/components/FormWizard/DynamicStep.jsx
@@ -16,18 +16,16 @@ const DynamicStep = ({
     defaultValues: formData,
   });
   const stepValues = watch();
+  const currentData = {
+    ...formData,
+    ...stepValues,
+  };
   return (
     <>
       <form onSubmit={handleSubmit((data) => onStepSubmit(data))}>
         <div className="govuk-form-group">
           {components?.map(({ conditionalRender, ...componentProps }) => {
-            if (
-              conditionalRender &&
-              !conditionalRender({
-                ...formData,
-                ...stepValues,
-              })
-            ) {
+            if (conditionalRender && !conditionalRender(currentData)) {
               return null;
             }
             return (
@@ -37,6 +35,7 @@ const DynamicStep = ({
                 register={register}
                 control={control}
                 errors={errors}
+                currentData={currentData}
                 multiStepIndex={isMulti && (parseInt(stepId[1]) - 1 || 0)}
                 {...componentProps}
               />

--- a/components/Summary/Summary.jsx
+++ b/components/Summary/Summary.jsx
@@ -82,14 +82,17 @@ export const SummarySection = ({
             );
           }
           if (component === 'Radios' || component === 'Select') {
+            const stepOptions =
+              typeof options === 'function' ? options(formData) : options;
             return {
               key: name,
               title: label,
               value:
-                typeof options[0] === 'string'
+                typeof stepOptions[0] === 'string'
                   ? formData[name]
-                  : options.find((option) => option.value === formData[name])
-                      ?.text,
+                  : stepOptions.find(
+                      (option) => option.value === formData[name]
+                    )?.text,
             };
           }
           if (component === 'DateInput') {

--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -56,6 +56,7 @@ describe('Test Form', () => {
         show_next_input: 'Y',
         show_next_step: true,
         show_object_step: false,
+        show_multi_select_step: false,
         conditional_text: 'conditional name',
         'last-step': [{ title_3: 'foo first' }, { title_3: 'foo second' }],
         title_2: 'conditional step title',

--- a/data/forms/test.jsx
+++ b/data/forms/test.jsx
@@ -1,3 +1,34 @@
+const MULTI_SELECT = {
+  foo: [
+    {
+      value: '1',
+      text: 'FOO',
+    },
+    {
+      value: '2',
+      text: 'Foo',
+    },
+    {
+      value: '3',
+      text: 'foo',
+    },
+  ],
+  bar: [
+    {
+      value: 'a',
+      text: 'BAR',
+    },
+    {
+      value: 'b',
+      text: 'Bar',
+    },
+    {
+      value: 'c',
+      text: 'bar',
+    },
+  ],
+};
+
 export default {
   title: 'Test Form',
   path: '/form/test/',
@@ -29,6 +60,12 @@ export default {
           name: 'show_next_step',
           width: '30',
           label: 'Show next step',
+        },
+        {
+          component: 'Checkbox',
+          name: 'show_multi_select_step',
+          width: '30',
+          label: 'Show multi-select step',
         },
         {
           component: 'Checkbox',
@@ -75,6 +112,27 @@ export default {
               label: 'Phone type',
             },
           ],
+        },
+      ],
+    },
+    {
+      id: 'multi-select-step',
+      title: 'Multi Select Step',
+      conditionalRender: ({ show_multi_select_step }) =>
+        show_multi_select_step === true,
+      components: [
+        {
+          component: 'Select',
+          name: 'first_select',
+          label: 'First multi select',
+          options: Object.keys(MULTI_SELECT),
+        },
+        {
+          conditionalRender: ({ first_select }) => first_select,
+          component: 'Select',
+          name: 'multi_select',
+          label: 'Second multi select',
+          options: ({ first_select } = {}) => MULTI_SELECT[first_select],
         },
       ],
     },


### PR DESCRIPTION
**What**  
It's now possible to pass a function to `options` in the form definition. The function will get the current form data as the first argument, in this way we can deal with inputs with options depending to other inputs (i.e. `ethnicity/sub-ethnicity`).

<img width="359" alt="Screenshot 2021-01-26 at 12 43 58" src="https://user-images.githubusercontent.com/435399/105847239-9f4d8180-5fdd-11eb-8e77-ade12928b84a.png">


**How to test it**
- go to http://dev.hackney.gov.uk:3000/form/test/first-step
- select **Show multi-select step**
- check that is working properly