### PR TITLE
fixed missing format on DateInput

### DIFF
--- a/components/Form/DateInput/DateInput.jsx
+++ b/components/Form/DateInput/DateInput.jsx
@@ -29,7 +29,7 @@ const DateInput = forwardRef(
   ) => {
     const date = stringDateToObject(value, format);
     const setNewDate = useCallback((newDate) =>
-      onChange(objectDateToString({ ...date, ...newDate }))
+      onChange(objectDateToString({ ...date, ...newDate }, format))
     );
     return (
       <div


### PR DESCRIPTION
**What**  
Fixed mising `format` for `objectDateToString`.

**How to test it**
- check `/cases`
- the date should work as expected