### PR TITLE
Fix props for allocation table

### DIFF
--- a/components/AllocatedWorkers/AllocatedWorkersTable.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkersTable.jsx
@@ -67,7 +67,7 @@ const AllocatedWorkersEntry = ({
     </>
   );
 };
-const AllocatedWorkersTable = ({ records, personName, updateWorkers }) => {
+const AllocatedWorkersTable = ({ records, updateWorkers }) => {
   const [selectedWorker, setSelectedWorker] = useState();
   return (
     <div>
@@ -75,7 +75,6 @@ const AllocatedWorkersTable = ({ records, personName, updateWorkers }) => {
         <AllocatedWorkersEntry
           key={index}
           index={index}
-          personName={personName}
           openModal={() => setSelectedWorker(index)}
           {...result}
         />
@@ -105,8 +104,11 @@ AllocatedWorkersTable.propTypes = {
       allocationStartDate: PropTypes.string.isRequired,
       allocationEndDate: PropTypes.string,
       workerType: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
+      personId: PropTypes.string.isRequired,
     })
   ).isRequired,
+  updateWorkers: PropTypes.func.isRequired,
 };
 
 export default AllocatedWorkersTable;

--- a/components/AllocatedWorkers/AllocatedWorkersTable.spec.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkersTable.spec.jsx
@@ -11,8 +11,11 @@ describe('AllocatedWorkers component', () => {
         allocationEndDate: '2019-03-28 00:00:00',
         allocationStartDate: '2019-03-28 00:00:00',
         workerType: 'Consultant Social Worker',
+        id: '123',
+        personId: '1234',
       },
     ],
+    updateWorkers: jest.fn(),
   };
   it('should render properly', () => {
     const { asFragment } = render(

--- a/components/AllocatedWorkers/DeallocateWorkerDetails/DeallocatedWorkerDetails.jsx
+++ b/components/AllocatedWorkers/DeallocateWorkerDetails/DeallocatedWorkerDetails.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import Link from 'next/link';
 import PropTypes from 'prop-types';
+
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { Button, TextArea } from 'components/Form';
 import Spinner from 'components/Spinner/Spinner';


### PR DESCRIPTION
**What**  
Removes the unneeded prop of `personName` from the `AllocatedWorkersTable` component and adds the missing prop types of `id` and `personId` to the `records` attribute and the `updateWorkers` function prop to the list of required prop types
**Why**  
To better reflect what props are actually needed for the component
**Anything else?**
Forgive the confusing branch name, this PR is supposed to just rectify the missing props from the component
