### PR TITLE
Added support for `isMulti` to the form components

### DIFF
--- a/components/Form/ObjectInput/ObjectInput.jsx
+++ b/components/Form/ObjectInput/ObjectInput.jsx
@@ -11,6 +11,9 @@ const ObjectInput = ({
   name,
   labelSize = 'm',
   isInline,
+  // this props is used for UI purpose in the summary
+  // eslint-disable-next-line no-unused-vars
+  summaryInline,
   components,
   ...otherProps
 }) => (
@@ -39,6 +42,7 @@ ObjectInput.propTypes = {
   label: PropTypes.string,
   labelSize: PropTypes.oneOf(['s', 'm', 'l', 'xl']),
   isInline: PropTypes.bool,
+  summaryInline: PropTypes.bool,
   hint: PropTypes.string,
   name: PropTypes.string.isRequired,
   components: PropTypes.array.isRequired,

--- a/components/Form/ObjectInput/ObjectInput.jsx
+++ b/components/Form/ObjectInput/ObjectInput.jsx
@@ -14,7 +14,7 @@ const ObjectInput = ({
   components,
   ...otherProps
 }) => (
-  <div className="govuk-form-group">
+  <div className="govuk-form-group govuk-!-margin-bottom-0">
     <label className={`govuk-label govuk-label--${labelSize}`}>{label}</label>
     {hint && (
       <span id={`${name}-hint`} className="govuk-hint">

--- a/components/Form/ObjectInput/ObjectInput.module.scss
+++ b/components/Form/ObjectInput/ObjectInput.module.scss
@@ -2,4 +2,9 @@
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   display: grid;
   column-gap: 1rem;
+  @media (min-width: 40.0625em) {
+    & > div {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/components/Form/ObjectInput/ObjectInput.spec.jsx
+++ b/components/Form/ObjectInput/ObjectInput.spec.jsx
@@ -50,22 +50,22 @@ describe('ObjectInput', () => {
       {}
     );
     expect(DynamicInput).toHaveBeenNthCalledWith(
-      1,
+      2,
       {
         component: 'TextInput',
         foo: 'bar',
         labelSize: 's',
-        name: 'oo.first',
+        name: 'oo.second',
       },
       {}
     );
     expect(DynamicInput).toHaveBeenNthCalledWith(
-      1,
+      3,
       {
         component: 'TextInput',
         foo: 'bar',
         labelSize: 's',
-        name: 'oo.first',
+        name: 'oo.third',
       },
       {}
     );

--- a/components/Form/ObjectInput/__snapshots__/ObjectInput.spec.jsx.snap
+++ b/components/Form/ObjectInput/__snapshots__/ObjectInput.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`ObjectInput should render properly 1`] = `
 <DocumentFragment>
   <div
-    class="govuk-form-group"
+    class="govuk-form-group govuk-!-margin-bottom-0"
   >
     <label
       class="govuk-label govuk-label--m"

--- a/components/FormWizard/DynamicInput.jsx
+++ b/components/FormWizard/DynamicInput.jsx
@@ -8,21 +8,15 @@ const DynamicInput = (props) => {
     register,
     control,
     errors,
-    id,
     name,
-    multiStepIndex,
     options,
     currentData,
     ...otherProps
   } = props;
-  const inputName =
-    typeof multiStepIndex === 'number'
-      ? `${id}[${multiStepIndex}].${name}`
-      : name;
   const Component = Inputs[component];
   const sharedProps = {
-    name: inputName,
-    error: errors[inputName],
+    name,
+    error: errors[name],
     required: otherProps?.rules?.required,
     options: typeof options === 'function' ? options(currentData) : options,
     ...otherProps,
@@ -44,14 +38,12 @@ DynamicInput.propTypes = {
   component: PropTypes.string.isRequired,
   register: PropTypes.func.isRequired,
   control: PropTypes.object.isRequired,
-  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   errors: PropTypes.object.isRequired,
   currentData: PropTypes.object.isRequired,
   rules: PropTypes.shape({
     required: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   }),
-  multiStepIndex: PropTypes.number,
 };
 
 export default DynamicInput;

--- a/components/FormWizard/DynamicInputMulti.jsx
+++ b/components/FormWizard/DynamicInputMulti.jsx
@@ -16,14 +16,16 @@ const DynamicInputMulti = ({
   hint,
   ...otherProps
 }) => {
+  console.log(currentData);
   const multiPresent = initialInputData.length || 0;
   const [counter, setCounter] = useState(multiPresent === 0 ? 1 : 0);
   const removeSelected = useCallback((index) => {
     setCounter(counter - 1);
-    onDelete([
-      ...currentData[name].slice(0, index),
-      ...currentData[name].slice(index + 1, currentData[name].length),
-    ]);
+    currentData[name] &&
+      onDelete([
+        ...currentData[name].slice(0, index),
+        ...currentData[name].slice(index + 1, currentData[name].length),
+      ]);
   });
   return (
     <>

--- a/components/FormWizard/DynamicInputMulti.jsx
+++ b/components/FormWizard/DynamicInputMulti.jsx
@@ -17,7 +17,6 @@ const DynamicInputMulti = ({
   isMultiTrigger = 'Add a new one',
   ...otherProps
 }) => {
-  console.log(currentData);
   const multiPresent = initialInputData.length || 0;
   const [counter, setCounter] = useState(multiPresent === 0 ? 1 : 0);
   const removeSelected = useCallback((index) => {

--- a/components/FormWizard/DynamicInputMulti.jsx
+++ b/components/FormWizard/DynamicInputMulti.jsx
@@ -14,6 +14,7 @@ const DynamicInputMulti = ({
   onDelete,
   label,
   hint,
+  isMultiTrigger = 'Add a new one',
   ...otherProps
 }) => {
   console.log(currentData);
@@ -58,7 +59,7 @@ const DynamicInputMulti = ({
           role="button"
           onClick={() => setCounter(counter + 1)}
         >
-          Add a new one
+          {isMultiTrigger}
         </span>
       </div>
     </>
@@ -72,6 +73,7 @@ DynamicInputMulti.propTypes = {
   initialInputData: PropTypes.array,
   currentData: PropTypes.object.isRequired,
   onDelete: PropTypes.func.isRequired,
+  isMultiTrigger: PropTypes.string,
 };
 
 export default DynamicInputMulti;

--- a/components/FormWizard/DynamicInputMulti.jsx
+++ b/components/FormWizard/DynamicInputMulti.jsx
@@ -1,0 +1,75 @@
+import { useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import DynamicInput from 'components/FormWizard/DynamicInput';
+import DeleteIcon from 'components/Icons/TimesCircle';
+
+import styles from './DynamicInputMulti.module.scss';
+
+const DynamicInputMulti = ({
+  name,
+  initialInputData = [],
+  currentData,
+  onDelete,
+  label,
+  hint,
+  ...otherProps
+}) => {
+  const multiPresent = initialInputData.length || 0;
+  const [counter, setCounter] = useState(multiPresent === 0 ? 1 : 0);
+  const removeSelected = useCallback((index) => {
+    setCounter(counter - 1);
+    onDelete([
+      ...currentData[name].slice(0, index),
+      ...currentData[name].slice(index + 1, currentData[name].length),
+    ]);
+  });
+  return (
+    <>
+      {Array.apply(null, { length: counter + multiPresent }).map((e, index) => (
+        <div
+          key={`${name}${index}`}
+          className={cx('govuk-!-margin-bottom-5', styles.wrapper)}
+        >
+          <DynamicInput
+            {...otherProps}
+            name={`${name}[${index}]`}
+            currentData={currentData}
+            label={index === 0 ? label : null}
+            hint={index === 0 ? hint : null}
+          />
+          {index !== 0 && (
+            <span
+              className={styles.delete}
+              role="button"
+              onClick={() => removeSelected(index)}
+            >
+              <DeleteIcon />
+            </span>
+          )}
+        </div>
+      ))}
+      <div className="govuk-!-margin-top-3 govuk-!-margin-bottom-5">
+        <span
+          className="govuk-link"
+          role="button"
+          onClick={() => setCounter(counter + 1)}
+        >
+          Add a new one
+        </span>
+      </div>
+    </>
+  );
+};
+
+DynamicInputMulti.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  hint: PropTypes.string,
+  initialInputData: PropTypes.array,
+  currentData: PropTypes.object.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+export default DynamicInputMulti;

--- a/components/FormWizard/DynamicInputMulti.module.scss
+++ b/components/FormWizard/DynamicInputMulti.module.scss
@@ -1,0 +1,10 @@
+.wrapper {
+  grid-template-columns: 1fr 1.5rem;
+  display: grid;
+  column-gap: 1rem;
+  align-items: flex-end;
+}
+
+.delete {
+  margin-bottom: 0.5rem;
+}

--- a/components/FormWizard/DynamicInputMulti.spec.jsx
+++ b/components/FormWizard/DynamicInputMulti.spec.jsx
@@ -1,0 +1,100 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import DynamicInputMulti from './DynamicInputMulti';
+
+import DynamicInput from 'components/FormWizard/DynamicInput';
+
+jest.mock('components/FormWizard/DynamicInput', () =>
+  jest.fn(() => 'MockedDynamicInput')
+);
+
+jest.mock('components/Icons/TimesCircle', () => () => 'MockedCloseButton');
+
+describe('DynamicInputMulti', () => {
+  const props = {
+    label: 'i am a multi input',
+    hint: 'i accept multiple inputs',
+    name: 'dynamic',
+    initialInputData: ['f', 'o', 'o'],
+    currentData: { foo: 'bar' },
+    isMulti: true,
+    component: 'Dynamic',
+    foo: 'bar',
+    onDelete: jest.fn(),
+  };
+
+  it('should render properly', () => {
+    const { asFragment } = render(<DynamicInputMulti {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should pass the correct props to DynamicInput', () => {
+    render(<DynamicInputMulti {...props} />);
+    expect(DynamicInput).toHaveBeenCalled();
+    expect(DynamicInput).toHaveBeenNthCalledWith(
+      1,
+      {
+        label: 'i am a multi input',
+        hint: 'i accept multiple inputs',
+        name: 'dynamic[0]',
+        currentData: { foo: 'bar' },
+        isMulti: true,
+        component: 'Dynamic',
+        foo: 'bar',
+      },
+      {}
+    );
+    expect(DynamicInput).toHaveBeenNthCalledWith(
+      2,
+      {
+        label: null,
+        hint: null,
+        name: 'dynamic[1]',
+        currentData: { foo: 'bar' },
+        isMulti: true,
+        component: 'Dynamic',
+        foo: 'bar',
+      },
+      {}
+    );
+    expect(DynamicInput).toHaveBeenNthCalledWith(
+      3,
+      {
+        label: null,
+        hint: null,
+        name: 'dynamic[2]',
+        currentData: { foo: 'bar' },
+        isMulti: true,
+        component: 'Dynamic',
+        foo: 'bar',
+      },
+      {}
+    );
+  });
+
+  it('should add a new input on "Add a new one"', () => {
+    const { getByText, getAllByText } = render(
+      <DynamicInputMulti
+        {...props}
+        initialInputData={['foo', 'bar']}
+        currentData={{ dynamic: [1, 2, 3] }}
+      />
+    );
+    expect(getAllByText('MockedCloseButton').length).toBe(1);
+    fireEvent.click(getByText('Add a new one'));
+    expect(getAllByText('MockedCloseButton').length).toBe(2);
+  });
+
+  it('should pass the updated data to onDelete', () => {
+    const { getByText } = render(
+      <DynamicInputMulti
+        {...props}
+        initialInputData={['foo', 'bar']}
+        currentData={{ dynamic: [1, 2, 3] }}
+      />
+    );
+    fireEvent.click(getByText('MockedCloseButton'));
+    expect(props.onDelete).toHaveBeenCalled();
+    expect(props.onDelete).toHaveBeenCalledWith([1, 3]);
+  });
+});

--- a/components/FormWizard/DynamicStep.jsx
+++ b/components/FormWizard/DynamicStep.jsx
@@ -20,23 +20,27 @@ const DynamicStep = ({
     ...formData,
     ...stepValues,
   };
+  const multiStepPrefix =
+    isMulti && `${stepId[0]}[${parseInt(stepId[1]) - 1 || 0}]`;
   return (
     <>
       <form onSubmit={handleSubmit((data) => onStepSubmit(data))}>
         <div className="govuk-form-group">
-          {components?.map(({ conditionalRender, ...componentProps }) => {
+          {components?.map(({ conditionalRender, name, ...componentProps }) => {
             if (conditionalRender && !conditionalRender(currentData)) {
               return null;
             }
+            const inputName = multiStepPrefix
+              ? `${multiStepPrefix}.${name}`
+              : name;
             return (
               <DynamicInput
-                key={componentProps.name}
-                id={stepId[0]}
+                key={inputName}
+                name={inputName}
                 register={register}
                 control={control}
                 errors={errors}
                 currentData={currentData}
-                multiStepIndex={isMulti && (parseInt(stepId[1]) - 1 || 0)}
                 {...componentProps}
               />
             );

--- a/components/FormWizard/DynamicStep.jsx
+++ b/components/FormWizard/DynamicStep.jsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 
 import Button from 'components/Button/Button';
 import DynamicInput from 'components/FormWizard/DynamicInput';
+import DynamicInputMulti from 'components/FormWizard/DynamicInputMulti';
 
 const DynamicStep = ({
   isMulti,
@@ -12,7 +13,7 @@ const DynamicStep = ({
   onStepSubmit,
   onSaveAndExit,
 }) => {
-  const { handleSubmit, register, control, errors, watch } = useForm({
+  const { handleSubmit, register, control, errors, setValue, watch } = useForm({
     defaultValues: formData,
   });
   const stepValues = watch();
@@ -26,25 +27,39 @@ const DynamicStep = ({
     <>
       <form onSubmit={handleSubmit((data) => onStepSubmit(data))}>
         <div className="govuk-form-group">
-          {components?.map(({ conditionalRender, name, ...componentProps }) => {
-            if (conditionalRender && !conditionalRender(currentData)) {
-              return null;
+          {components?.map(
+            ({
+              conditionalRender,
+              name,
+              isMulti: isComponentMulti,
+              ...componentProps
+            }) => {
+              if (conditionalRender && !conditionalRender(currentData)) {
+                return null;
+              }
+              const inputName = multiStepPrefix
+                ? `${multiStepPrefix}.${name}`
+                : name;
+              const sharedProps = {
+                key: inputName,
+                name: inputName,
+                register: register,
+                control: control,
+                errors: errors,
+                currentData: currentData,
+                ...componentProps,
+              };
+              return isComponentMulti ? (
+                <DynamicInputMulti
+                  {...sharedProps}
+                  initialInputData={formData[name]}
+                  onDelete={(updatedValue) => setValue(inputName, updatedValue)}
+                />
+              ) : (
+                <DynamicInput {...sharedProps} />
+              );
             }
-            const inputName = multiStepPrefix
-              ? `${multiStepPrefix}.${name}`
-              : name;
-            return (
-              <DynamicInput
-                key={inputName}
-                name={inputName}
-                register={register}
-                control={control}
-                errors={errors}
-                currentData={currentData}
-                {...componentProps}
-              />
-            );
-          })}
+          )}
         </div>
         {isMulti && (
           <Button

--- a/components/FormWizard/FormWizard.jsx
+++ b/components/FormWizard/FormWizard.jsx
@@ -80,7 +80,9 @@ const FormWizard = ({
           formSteps={formSteps}
           formPath={formPath}
           onStepSubmit={(data, addAnother) => {
-            const updatedData = deepmerge(formData, data);
+            const updatedData = step.isMulti
+              ? deepmerge(formData, data)
+              : { ...formData, ...data };
             setFormData(updatedData);
             step.onStepSubmit && step.onStepSubmit(updatedData);
             fromSummary &&
@@ -102,7 +104,9 @@ const FormWizard = ({
                 );
           }}
           onSaveAndExit={(data) => {
-            const updatedData = deepmerge(formData, data);
+            const updatedData = step.isMulti
+              ? deepmerge(formData, data)
+              : { ...formData, ...data };
             saveData(
               formPath,
               updatedData,

--- a/components/FormWizard/__snapshots__/DynamicInputMulti.spec.jsx.snap
+++ b/components/FormWizard/__snapshots__/DynamicInputMulti.spec.jsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DynamicInputMulti should render properly 1`] = `
+<DocumentFragment>
+  <div
+    class="govuk-!-margin-bottom-5 wrapper"
+  >
+    MockedDynamicInput
+  </div>
+  <div
+    class="govuk-!-margin-bottom-5 wrapper"
+  >
+    MockedDynamicInput
+    <span
+      class="delete"
+      role="button"
+    >
+      MockedCloseButton
+    </span>
+  </div>
+  <div
+    class="govuk-!-margin-bottom-5 wrapper"
+  >
+    MockedDynamicInput
+    <span
+      class="delete"
+      role="button"
+    >
+      MockedCloseButton
+    </span>
+  </div>
+  <div
+    class="govuk-!-margin-top-3 govuk-!-margin-bottom-5"
+  >
+    <span
+      class="govuk-link"
+      role="button"
+    >
+      Add a new one
+    </span>
+  </div>
+</DocumentFragment>
+`;

--- a/components/Summary/Summary.jsx
+++ b/components/Summary/Summary.jsx
@@ -3,17 +3,7 @@ import Link from 'next/link';
 
 import SummaryList from 'components/Summary/SummaryList';
 import { filterStepsOnCondition, filterDataOnCondition } from 'utils/steps';
-import { convertFormat } from 'utils/date';
-
-const MultiValue = ([key, value], summaryInline) =>
-  summaryInline ? (
-    <span key={key}>{value} </span>
-  ) : (
-    <div key={key}>
-      <span>{value}</span>
-      <br />
-    </div>
-  );
+import { formatData } from 'utils/summary';
 
 const SummaryMultiSection = ({
   formData,
@@ -60,64 +50,7 @@ export const SummarySection = ({
     <SummaryList
       list={components
         .filter(({ name }) => formData[name])
-        .map(({ component, options, name, label, summaryInline }) => {
-          if (component === 'AddressLookup') {
-            const { address, postcode } = formData[name];
-            return (
-              address && {
-                key: name,
-                title: label,
-                value: (
-                  <>
-                    {address.split(', ').map((value) => (
-                      <div key={value}>
-                        <span>{value}</span>
-                        <br />
-                      </div>
-                    ))}
-                    <div>{postcode}</div>
-                  </>
-                ),
-              }
-            );
-          }
-          if (component === 'Radios' || component === 'Select') {
-            const stepOptions =
-              typeof options === 'function' ? options(formData) : options;
-            return {
-              key: name,
-              title: label,
-              value:
-                typeof stepOptions[0] === 'string'
-                  ? formData[name]
-                  : stepOptions.find(
-                      (option) => option.value === formData[name]
-                    )?.text,
-            };
-          }
-          if (component === 'DateInput') {
-            return {
-              key: name,
-              title: label,
-              value: convertFormat(formData[name]),
-            };
-          }
-          return {
-            key: name,
-            title: label,
-            value: Array.isArray(formData[name])
-              ? formData[name]
-                  .filter(Boolean)
-                  .map((v) => MultiValue(v.split('/').pop()))
-              : typeof formData[name] === 'object'
-              ? Object.entries(formData[name])
-                  .filter(([, value]) => Boolean(value))
-                  .map((entry) => MultiValue(entry, summaryInline))
-              : typeof formData[name] === 'boolean'
-              ? JSON.stringify(formData[name])
-              : formData[name],
-          };
-        })}
+        .map((data) => formatData(data, formData))}
     />
   );
   return (

--- a/data/forms/create-new-person.jsx
+++ b/data/forms/create-new-person.jsx
@@ -72,6 +72,27 @@ export default {
           label: 'Address',
           rules: { required: true },
         },
+        {
+          component: 'ObjectInput',
+          name: 'phone_number',
+          label: 'Phone Number',
+          isInline: true,
+          isMulti: true,
+          summaryInline: true,
+          components: [
+            {
+              component: 'PhoneInput',
+              name: 'phoneNumber',
+              label: 'Phone number',
+              rules: { required: true },
+            },
+            {
+              component: 'TextInput',
+              name: 'phoneType',
+              label: 'Phone type',
+            },
+          ],
+        },
       ],
     },
   ],

--- a/data/forms/create-new-person.jsx
+++ b/data/forms/create-new-person.jsx
@@ -78,6 +78,7 @@ export default {
           label: 'Phone Number',
           isInline: true,
           isMulti: true,
+          isMultiTrigger: '+ Add additional phone number',
           summaryInline: true,
           components: [
             {

--- a/data/forms/test.jsx
+++ b/data/forms/test.jsx
@@ -94,10 +94,18 @@ export default {
       conditionalRender: ({ show_object_step }) => show_object_step === true,
       components: [
         {
+          component: 'TextInput',
+          name: 'title_2',
+          width: '30',
+          label: 'Title',
+          isMulti: true,
+        },
+        {
           component: 'ObjectInput',
           name: 'phone_number',
           label: 'Phone Number',
           isInline: true,
+          isMulti: true,
           summaryInline: true,
           components: [
             {

--- a/docs/formBuilder/03-FormComponents.stories.mdx
+++ b/docs/formBuilder/03-FormComponents.stories.mdx
@@ -24,6 +24,7 @@ Each component has the following properties:
 - `rules` for validation, is an object that is reflecting the [react-hook-form](https://react-hook-form.com/api/) validation APIs
 - `label` the input label
 - `isMulti` is it possible to add arbitrary values for the component input
+- `isMultiTrigger` the custom text for the `isMulti` functionality
 
 There are other properties that depend on the input type, for example, `options` for `CheckBox` or `width` for `TextInput`.
 

--- a/docs/formBuilder/03-FormComponents.stories.mdx
+++ b/docs/formBuilder/03-FormComponents.stories.mdx
@@ -23,6 +23,7 @@ Each component has the following properties:
 - `name` the name of the property that is going to contain the value of the input
 - `rules` for validation, is an object that is reflecting the [react-hook-form](https://react-hook-form.com/api/) validation APIs
 - `label` the input label
+- `isMulti` is it possible to add arbitrary values for the component input
 
 There are other properties that depend on the input type, for example, `options` for `CheckBox` or `width` for `TextInput`.
 

--- a/utils/__snapshots__/summary.spec.jsx.snap
+++ b/utils/__snapshots__/summary.spec.jsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Summary utils formatData should format "TextInput isMulti" properly 1`] = `
+Object {
+  "key": "text",
+  "title": "Some_text",
+  "value": <React.Fragment>
+    <div>
+      i
+    </div>
+    <div>
+      m
+    </div>
+    <div>
+      multi
+    </div>
+    <div>
+      text
+    </div>
+  </React.Fragment>,
+}
+`;

--- a/utils/__snapshots__/summary.spec.jsx.snap
+++ b/utils/__snapshots__/summary.spec.jsx.snap
@@ -1,5 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Summary utils formatData should format "AddressLookup" properly 1`] = `
+Object {
+  "key": "main_address",
+  "title": "main address",
+  "value": <React.Fragment>
+    <div>
+      <span>
+        first line
+      </span>
+      <br />
+    </div>
+    <div>
+      <span>
+        second line
+      </span>
+      <br />
+    </div>
+    <div>
+      <span>
+        third line
+      </span>
+      <br />
+    </div>
+    <div>
+      postcode
+    </div>
+  </React.Fragment>,
+}
+`;
+
+exports[`Summary utils formatData should format "ObjectInput" properly 1`] = `
+Object {
+  "key": "oo",
+  "title": "I am object component",
+  "value": Array [
+    <div>
+      <span>
+        first
+      </span>
+      <br />
+    </div>,
+    <div>
+      <span>
+        second
+      </span>
+      <br />
+    </div>,
+    <div>
+      <span>
+        third
+      </span>
+      <br />
+    </div>,
+  ],
+}
+`;
+
+exports[`Summary utils formatData should format "ObjectInput" properly 2`] = `
+Object {
+  "key": "oi",
+  "title": "I am object component inline",
+  "value": Array [
+    <span>
+      first
+       
+    </span>,
+    <span>
+      second
+       
+    </span>,
+    <span>
+      third
+       
+    </span>,
+  ],
+}
+`;
+
 exports[`Summary utils formatData should format "TextInput isMulti" properly 1`] = `
 Object {
   "key": "text",

--- a/utils/summary.jsx
+++ b/utils/summary.jsx
@@ -1,0 +1,71 @@
+import { convertFormat } from 'utils/date';
+
+const multiValue = ([key, value], summaryInline) =>
+  summaryInline ? (
+    <span key={key}>{value} </span>
+  ) : (
+    <div key={key}>
+      <span>{value}</span>
+      <br />
+    </div>
+  );
+
+const address = ({ address, postcode }, name, label) =>
+  address && {
+    key: name,
+    title: label,
+    value: (
+      <>
+        {address.split(', ').map((value) => (
+          <div key={value}>
+            <span>{value}</span>
+            <br />
+          </div>
+        ))}
+        <div>{postcode}</div>
+      </>
+    ),
+  };
+
+export const formatData = (
+  { component, options, name, label, summaryInline },
+  formData
+) => {
+  if (component === 'AddressLookup') {
+    return address(formData[name], name, label);
+  }
+  if (component === 'Radios' || component === 'Select') {
+    const stepOptions =
+      typeof options === 'function' ? options(formData) : options;
+    return {
+      key: name,
+      title: label,
+      value:
+        typeof stepOptions[0] === 'string'
+          ? formData[name]
+          : stepOptions.find((option) => option.value === formData[name])?.text,
+    };
+  }
+  if (component === 'DateInput') {
+    return {
+      key: name,
+      title: label,
+      value: convertFormat(formData[name]),
+    };
+  }
+  return {
+    key: name,
+    title: label,
+    value: Array.isArray(formData[name])
+      ? formData[name]
+          .filter(Boolean)
+          .map((v) => multiValue(v.split('/').pop()))
+      : typeof formData[name] === 'object'
+      ? Object.entries(formData[name])
+          .filter(([, value]) => Boolean(value))
+          .map((entry) => multiValue(entry, summaryInline))
+      : typeof formData[name] === 'boolean'
+      ? JSON.stringify(formData[name])
+      : formData[name],
+  };
+};

--- a/utils/summary.jsx
+++ b/utils/summary.jsx
@@ -10,7 +10,22 @@ const multiValue = ([key, value], summaryInline) =>
     </div>
   );
 
-const address = ({ address, postcode }, name, label) =>
+const formatIsMulti = (formData, componentProps) => (
+  <>
+    {formData
+      .map((multiData, index) => ({
+        ...formatData(componentProps, {
+          [componentProps.name]: multiData,
+        }),
+        key: `${componentProps.name}_${index}`,
+      }))
+      ?.map(({ key, value }) => (
+        <div key={key}>{value}</div>
+      ))}
+  </>
+);
+
+const formatAddress = ({ address, postcode }, name, label) =>
   address && {
     key: name,
     title: label,
@@ -27,12 +42,17 @@ const address = ({ address, postcode }, name, label) =>
     ),
   };
 
-export const formatData = (
-  { component, options, name, label, summaryInline },
-  formData
-) => {
+export const formatData = (componentProps, formData) => {
+  const {
+    component,
+    options,
+    name,
+    label,
+    isMulti,
+    summaryInline,
+  } = componentProps;
   if (component === 'AddressLookup') {
-    return address(formData[name], name, label);
+    return formatAddress(formData[name], name, label);
   }
   if (component === 'Radios' || component === 'Select') {
     const stepOptions =
@@ -57,9 +77,11 @@ export const formatData = (
     key: name,
     title: label,
     value: Array.isArray(formData[name])
-      ? formData[name]
-          .filter(Boolean)
-          .map((v) => multiValue(v.split('/').pop()))
+      ? isMulti
+        ? formatIsMulti(formData[name], componentProps)
+        : formData[name]
+            .filter(Boolean)
+            .map((v) => multiValue(v.split('/').pop()))
       : typeof formData[name] === 'object'
       ? Object.entries(formData[name])
           .filter(([, value]) => Boolean(value))

--- a/utils/summary.spec.jsx
+++ b/utils/summary.spec.jsx
@@ -2,106 +2,106 @@ import { formatData } from './summary';
 
 describe('Summary utils', () => {
   describe('formatData', () => {
-    // it('should format "AddressLookup" properly', () => {
-    //   const componentProps = {
-    //     component: 'AddressLookup',
-    //     name: 'main_address',
-    //     label: 'main address',
-    //   };
-    //   const formData = {
-    //     main_address: {
-    //       address: 'first line, second line, third line',
-    //       postcode: 'postcode',
-    //       uprn: '123123',
-    //     },
-    //   };
-    //   expect(formatData(componentProps, formData)).toMatchSnapshot();
-    // });
+    it('should format "AddressLookup" properly', () => {
+      const componentProps = {
+        component: 'AddressLookup',
+        name: 'main_address',
+        label: 'main address',
+      };
+      const formData = {
+        main_address: {
+          address: 'first line, second line, third line',
+          postcode: 'postcode',
+          uprn: '123123',
+        },
+      };
+      expect(formatData(componentProps, formData)).toMatchSnapshot();
+    });
 
-    // it('should format "DateInput" properly', () => {
-    //   const componentProps = {
-    //     component: 'DateInput',
-    //     name: 'first_date',
-    //     label: 'Frst date',
-    //   };
-    //   const formData = {
-    //     first_date: '2000-10-01',
-    //   };
-    //   expect(formatData(componentProps, formData)).toEqual({
-    //     key: 'first_date',
-    //     title: 'Frst date',
-    //     value: '01-10-2000',
-    //   });
-    // });
+    it('should format "DateInput" properly', () => {
+      const componentProps = {
+        component: 'DateInput',
+        name: 'first_date',
+        label: 'Frst date',
+      };
+      const formData = {
+        first_date: '2000-10-01',
+      };
+      expect(formatData(componentProps, formData)).toEqual({
+        key: 'first_date',
+        title: 'Frst date',
+        value: '01-10-2000',
+      });
+    });
 
-    // it('should format "ObjectInput" properly', () => {
-    //   const objectComponents = [
-    //     {
-    //       component: 'TextInput',
-    //       name: 'first',
-    //     },
-    //     {
-    //       component: 'TextInput',
-    //       name: 'second',
-    //     },
-    //     {
-    //       component: 'TextInput',
-    //       name: 'third',
-    //     },
-    //   ];
-    //   const componentProps = {
-    //     component: 'ObjectInput',
-    //     label: 'I am object component',
-    //     name: 'oo',
-    //     components: objectComponents,
-    //   };
-    //   const componentPropsInline = {
-    //     component: 'ObjectInput',
-    //     label: 'I am object component inline',
-    //     name: 'oi',
-    //     summaryInline: true,
-    //     components: objectComponents,
-    //   };
-    //   const formData = {
-    //     oo: { first: 'first', second: 'second', third: 'third' },
-    //     oi: { first: 'first', second: 'second', third: 'third' },
-    //   };
-    //   expect(formatData(componentProps, formData)).toMatchSnapshot();
-    //   expect(formatData(componentPropsInline, formData)).toMatchSnapshot();
-    // });
+    it('should format "ObjectInput" properly', () => {
+      const objectComponents = [
+        {
+          component: 'TextInput',
+          name: 'first',
+        },
+        {
+          component: 'TextInput',
+          name: 'second',
+        },
+        {
+          component: 'TextInput',
+          name: 'third',
+        },
+      ];
+      const componentProps = {
+        component: 'ObjectInput',
+        label: 'I am object component',
+        name: 'oo',
+        components: objectComponents,
+      };
+      const componentPropsInline = {
+        component: 'ObjectInput',
+        label: 'I am object component inline',
+        name: 'oi',
+        summaryInline: true,
+        components: objectComponents,
+      };
+      const formData = {
+        oo: { first: 'first', second: 'second', third: 'third' },
+        oi: { first: 'first', second: 'second', third: 'third' },
+      };
+      expect(formatData(componentProps, formData)).toMatchSnapshot();
+      expect(formatData(componentPropsInline, formData)).toMatchSnapshot();
+    });
 
-    // it('should format "Select" properly', () => {
-    //   const SelectProps = {
-    //     component: 'Select',
-    //     name: 'select',
-    //     label: 'Select component',
-    //     options: ['Yes', 'No'],
-    //   };
-    //   const SubSelectProps = {
-    //     component: 'Select',
-    //     name: 'subselect',
-    //     label: 'Sub-Select component',
-    //     options: ({ select }) =>
-    //       select === 'Yes' && [
-    //         { value: 'foo', text: 'I am Foo' },
-    //         { value: 'bar', text: 'I am bar' },
-    //       ],
-    //   };
-    //   const formData = {
-    //     select: 'Yes',
-    //     subselect: 'foo',
-    //   };
-    //   expect(formatData(SelectProps, formData)).toEqual({
-    //     key: 'select',
-    //     title: 'Select component',
-    //     value: 'Yes',
-    //   });
-    //   expect(formatData(SubSelectProps, formData)).toEqual({
-    //     key: 'subselect',
-    //     title: 'Sub-Select component',
-    //     value: 'I am Foo',
-    //   });
-    // });
+    it('should format "Select" properly', () => {
+      const SelectProps = {
+        component: 'Select',
+        name: 'select',
+        label: 'Select component',
+        options: ['Yes', 'No'],
+      };
+      const SubSelectProps = {
+        component: 'Select',
+        name: 'subselect',
+        label: 'Sub-Select component',
+        options: ({ select }) =>
+          select === 'Yes' && [
+            { value: 'foo', text: 'I am Foo' },
+            { value: 'bar', text: 'I am bar' },
+          ],
+      };
+      const formData = {
+        select: 'Yes',
+        subselect: 'foo',
+      };
+      expect(formatData(SelectProps, formData)).toEqual({
+        key: 'select',
+        title: 'Select component',
+        value: 'Yes',
+      });
+      expect(formatData(SubSelectProps, formData)).toEqual({
+        key: 'subselect',
+        title: 'Sub-Select component',
+        value: 'I am Foo',
+      });
+    });
 
     it('should format "TextInput isMulti" properly', () => {
       const componentProps = {

--- a/utils/summary.spec.jsx
+++ b/utils/summary.spec.jsx
@@ -1,0 +1,106 @@
+import { formatData } from './summary';
+
+describe('Summary utils', () => {
+  describe('formatData', () => {
+    it('should format "AddressLookup" properly', () => {
+      const componentProps = {
+        component: 'AddressLookup',
+        name: 'main_address',
+        label: 'main address',
+      };
+      const formData = {
+        main_address: {
+          address: 'first line, second line, third line',
+          postcode: 'postcode',
+          uprn: '123123',
+        },
+      };
+      expect(formatData(componentProps, formData)).toMatchSnapshot();
+    });
+
+    it('should format "DateInput" properly', () => {
+      const componentProps = {
+        component: 'DateInput',
+        name: 'first_date',
+        label: 'Frst date',
+      };
+      const formData = {
+        first_date: '2000-10-01',
+      };
+      expect(formatData(componentProps, formData)).toEqual({
+        key: 'first_date',
+        title: 'Frst date',
+        value: '01-10-2000',
+      });
+    });
+
+    it('should format "ObjectInput" properly', () => {
+      const objectComponents = [
+        {
+          component: 'TextInput',
+          name: 'first',
+        },
+        {
+          component: 'TextInput',
+          name: 'second',
+        },
+        {
+          component: 'TextInput',
+          name: 'third',
+        },
+      ];
+      const componentProps = {
+        component: 'ObjectInput',
+        label: 'I am object component',
+        name: 'oo',
+        components: objectComponents,
+      };
+      const componentPropsInline = {
+        component: 'ObjectInput',
+        label: 'I am object component inline',
+        name: 'oi',
+        summaryInline: true,
+        components: objectComponents,
+      };
+      const formData = {
+        oo: { first: 'first', second: 'second', third: 'third' },
+        oi: { first: 'first', second: 'second', third: 'third' },
+      };
+      expect(formatData(componentProps, formData)).toMatchSnapshot();
+      expect(formatData(componentPropsInline, formData)).toMatchSnapshot();
+    });
+
+    it('should format "Select" properly', () => {
+      const SelectProps = {
+        component: 'Select',
+        name: 'select',
+        label: 'Select component',
+        options: ['Yes', 'No'],
+      };
+      const SubSelectProps = {
+        component: 'Select',
+        name: 'subselect',
+        label: 'Sub-Select component',
+        options: ({ select }) =>
+          select === 'Yes' && [
+            { value: 'foo', text: 'I am Foo' },
+            { value: 'bar', text: 'I am bar' },
+          ],
+      };
+      const formData = {
+        select: 'Yes',
+        subselect: 'foo',
+      };
+      expect(formatData(SelectProps, formData)).toEqual({
+        key: 'select',
+        title: 'Select component',
+        value: 'Yes',
+      });
+      expect(formatData(SubSelectProps, formData)).toEqual({
+        key: 'subselect',
+        title: 'Sub-Select component',
+        value: 'I am Foo',
+      });
+    });
+  });
+});

--- a/utils/summary.spec.jsx
+++ b/utils/summary.spec.jsx
@@ -2,105 +2,118 @@ import { formatData } from './summary';
 
 describe('Summary utils', () => {
   describe('formatData', () => {
-    it('should format "AddressLookup" properly', () => {
+    // it('should format "AddressLookup" properly', () => {
+    //   const componentProps = {
+    //     component: 'AddressLookup',
+    //     name: 'main_address',
+    //     label: 'main address',
+    //   };
+    //   const formData = {
+    //     main_address: {
+    //       address: 'first line, second line, third line',
+    //       postcode: 'postcode',
+    //       uprn: '123123',
+    //     },
+    //   };
+    //   expect(formatData(componentProps, formData)).toMatchSnapshot();
+    // });
+
+    // it('should format "DateInput" properly', () => {
+    //   const componentProps = {
+    //     component: 'DateInput',
+    //     name: 'first_date',
+    //     label: 'Frst date',
+    //   };
+    //   const formData = {
+    //     first_date: '2000-10-01',
+    //   };
+    //   expect(formatData(componentProps, formData)).toEqual({
+    //     key: 'first_date',
+    //     title: 'Frst date',
+    //     value: '01-10-2000',
+    //   });
+    // });
+
+    // it('should format "ObjectInput" properly', () => {
+    //   const objectComponents = [
+    //     {
+    //       component: 'TextInput',
+    //       name: 'first',
+    //     },
+    //     {
+    //       component: 'TextInput',
+    //       name: 'second',
+    //     },
+    //     {
+    //       component: 'TextInput',
+    //       name: 'third',
+    //     },
+    //   ];
+    //   const componentProps = {
+    //     component: 'ObjectInput',
+    //     label: 'I am object component',
+    //     name: 'oo',
+    //     components: objectComponents,
+    //   };
+    //   const componentPropsInline = {
+    //     component: 'ObjectInput',
+    //     label: 'I am object component inline',
+    //     name: 'oi',
+    //     summaryInline: true,
+    //     components: objectComponents,
+    //   };
+    //   const formData = {
+    //     oo: { first: 'first', second: 'second', third: 'third' },
+    //     oi: { first: 'first', second: 'second', third: 'third' },
+    //   };
+    //   expect(formatData(componentProps, formData)).toMatchSnapshot();
+    //   expect(formatData(componentPropsInline, formData)).toMatchSnapshot();
+    // });
+
+    // it('should format "Select" properly', () => {
+    //   const SelectProps = {
+    //     component: 'Select',
+    //     name: 'select',
+    //     label: 'Select component',
+    //     options: ['Yes', 'No'],
+    //   };
+    //   const SubSelectProps = {
+    //     component: 'Select',
+    //     name: 'subselect',
+    //     label: 'Sub-Select component',
+    //     options: ({ select }) =>
+    //       select === 'Yes' && [
+    //         { value: 'foo', text: 'I am Foo' },
+    //         { value: 'bar', text: 'I am bar' },
+    //       ],
+    //   };
+    //   const formData = {
+    //     select: 'Yes',
+    //     subselect: 'foo',
+    //   };
+    //   expect(formatData(SelectProps, formData)).toEqual({
+    //     key: 'select',
+    //     title: 'Select component',
+    //     value: 'Yes',
+    //   });
+    //   expect(formatData(SubSelectProps, formData)).toEqual({
+    //     key: 'subselect',
+    //     title: 'Sub-Select component',
+    //     value: 'I am Foo',
+    //   });
+    // });
+
+    it('should format "TextInput isMulti" properly', () => {
       const componentProps = {
-        component: 'AddressLookup',
-        name: 'main_address',
-        label: 'main address',
+        component: 'TextInput',
+        name: 'text',
+        label: 'Some_text',
+        isMulti: true,
       };
       const formData = {
-        main_address: {
-          address: 'first line, second line, third line',
-          postcode: 'postcode',
-          uprn: '123123',
-        },
+        text: ['i', 'm', 'multi', 'text'],
       };
       expect(formatData(componentProps, formData)).toMatchSnapshot();
-    });
-
-    it('should format "DateInput" properly', () => {
-      const componentProps = {
-        component: 'DateInput',
-        name: 'first_date',
-        label: 'Frst date',
-      };
-      const formData = {
-        first_date: '2000-10-01',
-      };
-      expect(formatData(componentProps, formData)).toEqual({
-        key: 'first_date',
-        title: 'Frst date',
-        value: '01-10-2000',
-      });
-    });
-
-    it('should format "ObjectInput" properly', () => {
-      const objectComponents = [
-        {
-          component: 'TextInput',
-          name: 'first',
-        },
-        {
-          component: 'TextInput',
-          name: 'second',
-        },
-        {
-          component: 'TextInput',
-          name: 'third',
-        },
-      ];
-      const componentProps = {
-        component: 'ObjectInput',
-        label: 'I am object component',
-        name: 'oo',
-        components: objectComponents,
-      };
-      const componentPropsInline = {
-        component: 'ObjectInput',
-        label: 'I am object component inline',
-        name: 'oi',
-        summaryInline: true,
-        components: objectComponents,
-      };
-      const formData = {
-        oo: { first: 'first', second: 'second', third: 'third' },
-        oi: { first: 'first', second: 'second', third: 'third' },
-      };
-      expect(formatData(componentProps, formData)).toMatchSnapshot();
-      expect(formatData(componentPropsInline, formData)).toMatchSnapshot();
-    });
-
-    it('should format "Select" properly', () => {
-      const SelectProps = {
-        component: 'Select',
-        name: 'select',
-        label: 'Select component',
-        options: ['Yes', 'No'],
-      };
-      const SubSelectProps = {
-        component: 'Select',
-        name: 'subselect',
-        label: 'Sub-Select component',
-        options: ({ select }) =>
-          select === 'Yes' && [
-            { value: 'foo', text: 'I am Foo' },
-            { value: 'bar', text: 'I am bar' },
-          ],
-      };
-      const formData = {
-        select: 'Yes',
-        subselect: 'foo',
-      };
-      expect(formatData(SelectProps, formData)).toEqual({
-        key: 'select',
-        title: 'Select component',
-        value: 'Yes',
-      });
-      expect(formatData(SubSelectProps, formData)).toEqual({
-        key: 'subselect',
-        title: 'Sub-Select component',
-        value: 'I am Foo',
-      });
     });
   });
 });


### PR DESCRIPTION
**What**  
- simplified the `DynamicInput`
- introduced the `DynamicInputMulti` that is taking care of add multiple instances of the same input
- extracted the summary formatting login in an ad-hoc component `utils/summary` and added test coverage
- fixed `ObjestInput` test
- Reverted "removed summaryInline from the props"
- added phone number in `create-person` form
- small style tweaks

**How is working**
Every input now support `isMulti` and `isMultiTrigger`
```
{
  component: 'Object',
  name: 'phone_number',
  label: 'Phone Number',
  isMulti: true,
  components: [
    {
      component: 'PhoneInput',
      name: 'phoneNumber',
      label: 'Phone number',
      rules: { required: true },
    },
    {
      component: 'TextInput',
      name: 'phoneType',
      label: 'Phone type',
    },
  ],
},
```
is returning:
```
[
	  {
	    phoneType: "main contact",
	    phoneNumber: "077..."
	  },
      {
	    phoneType: "second contact",
	    phoneNumber: "077..."
	  },
	  ...
]
```

**Notes**
- At the moment is not possible to have a `isMulti` component in a `isMulti` step

**How to test it**
- check `create-person` form
or
- go to http://dev.hackney.gov.uk:3000/form/test/first-step
- select show object step
- check that is working properly

<img width="1004" alt="Screenshot 2021-01-27 at 18 36 12" src="https://user-images.githubusercontent.com/435399/106038087-c5efe300-60d7-11eb-89a1-9af51076b206.png">
<img width="1005" alt="Screenshot 2021-01-27 at 17 36 15" src="https://user-images.githubusercontent.com/435399/106038098-cb4d2d80-60d7-11eb-8152-7a2197850a88.png">
