### PR TITLE
Refactored `AddForm` to use the getResident results from the parent

### DIFF
--- a/components/AddForm/AddForm.jsx
+++ b/components/AddForm/AddForm.jsx
@@ -1,103 +1,76 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import LinkButton from 'components/LinkButton/LinkButton';
-import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
-import Spinner from 'components/Spinner/Spinner';
 import { useAuth } from 'components/UserContext/UserContext';
 import { Select } from 'components/Form';
-import { getResident } from 'utils/api/residents';
 import { populateChildForm } from 'utils/populate';
 import ADULT_CATE from 'data/googleForms/adultCategories';
 import ADULT_FORMS from 'data/googleForms/adultForms';
 import CHILD_CATE from 'data/googleForms/childCategories';
 import CHILD_FORMS from 'data/googleForms/childForms';
 
-const AddForm = ({ id }) => {
+const AddForm = ({ person }) => {
   const { user } = useAuth();
-  const [loading, setLoading] = useState(true);
-  const [person, setPerson] = useState();
-  const [error, setError] = useState();
   const [url, setUrl] = useState();
   const [categoryValue, setCategoryValue] = useState();
   const ageContext = person && person.ageContext;
   const category = ageContext === 'C' ? CHILD_CATE : ADULT_CATE;
   const forms = ageContext === 'C' ? CHILD_FORMS : ADULT_FORMS;
 
-  const getPerson = async () => {
-    try {
-      const data = await getResident(id);
-      setPerson(data);
-      setLoading(false);
-      setError(false);
-    } catch (e) {
-      setPerson(null);
-      setLoading(false);
-      setError(true);
-    }
-  };
-  useEffect(() => {
-    getPerson();
-  }, []);
-
-  if (loading) {
-    return <Spinner />;
-  }
   return (
     <>
-      {error && <ErrorMessage />}
-      {person && (
-        <>
-          <div className={cx('govuk-grid-row')}>
-            <Select
-              govGrid="one-half"
-              name="category"
-              options={category}
-              label="Choose a form category"
-              placeHolder="Choose one"
-              width={30}
-              onChange={(value) => setCategoryValue(value)}
-            />
-            {categoryValue && (
-              <Select
-                govGrid="one-half"
-                name="formList"
-                width={30}
-                options={forms.filter(
-                  (form) => form.category === categoryValue
-                )}
-                label="Choose a form"
-                placeHolder="Choose one"
-                onChange={(value) => setUrl(value)}
-              />
-            )}
-          </div>
-          {url && (
-            <LinkButton
-              label="Load form"
-              route={
-                ageContext === 'C'
-                  ? `${url}${populateChildForm(
-                      person.firstName,
-                      person.lastName,
-                      person.mosaicId,
-                      user.name,
-                      url
-                    )}`
-                  : url
-              }
-              internalQuery={`?id=${id}`}
-            />
-          )}
-        </>
+      <div className={cx('govuk-grid-row')}>
+        <Select
+          govGrid="one-half"
+          name="category"
+          options={category}
+          label="Choose a form category"
+          placeHolder="Choose one"
+          width={30}
+          onChange={(value) => setCategoryValue(value)}
+        />
+        {categoryValue && (
+          <Select
+            govGrid="one-half"
+            name="formList"
+            width={30}
+            options={forms.filter((form) => form.category === categoryValue)}
+            label="Choose a form"
+            placeHolder="Choose one"
+            onChange={(value) => setUrl(value)}
+          />
+        )}
+      </div>
+      {url && (
+        <LinkButton
+          label="Load form"
+          route={
+            ageContext === 'C'
+              ? `${url}${populateChildForm(
+                  person.firstName,
+                  person.lastName,
+                  person.mosaicId,
+                  user.name,
+                  url
+                )}`
+              : url
+          }
+          internalQuery={`?id=${person.mosaicId}`}
+        />
       )}
     </>
   );
 };
 
 AddForm.propTypes = {
-  id: PropTypes.string.isRequired,
+  person: PropTypes.shape({
+    mosaicId: PropTypes.string.isRequired,
+    ageContext: PropTypes.string.isRequired,
+    firstName: PropTypes.string.isRequired,
+    lastName: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default AddForm;

--- a/components/AddForm/AddForm.spec.jsx
+++ b/components/AddForm/AddForm.spec.jsx
@@ -1,29 +1,25 @@
 import { render, waitFor, fireEvent } from '@testing-library/react';
+
 import AddForm from './AddForm';
 import { UserContext } from 'components/UserContext/UserContext';
-import { getResident } from 'utils/api/residents';
-
-jest.mock('utils/api/residents', () => ({
-  getResident: jest.fn(),
-}));
 
 describe('AddForm component', () => {
   it('should render adult forms', async () => {
-    getResident.mockImplementation(() =>
-      Promise.resolve({
+    const props = {
+      person: {
         firstName: 'Foo',
         lastName: 'Bar',
         mosaicId: '123',
         ageContext: 'A',
-      })
-    );
+      },
+    };
     const { getByTestId, getByText, getByRole } = render(
       <UserContext.Provider
         value={{
           user: { name: 'Nom', email: 'i am the email' },
         }}
       >
-        <AddForm id="123" />
+        <AddForm {...props} />
       </UserContext.Provider>
     );
 
@@ -40,21 +36,21 @@ describe('AddForm component', () => {
   });
 
   it('should render children forms', async () => {
-    getResident.mockImplementation(() =>
-      Promise.resolve({
+    const props = {
+      person: {
         firstName: 'Foo',
         lastName: 'Bar',
         mosaicId: '123',
         ageContext: 'C',
-      })
-    );
+      },
+    };
     const { getByRole, asFragment, getByText, getByTestId } = render(
       <UserContext.Provider
         value={{
           user: { name: 'Nom', email: 'i am the email' },
         }}
       >
-        <AddForm id="123" />
+        <AddForm {...props} />
       </UserContext.Provider>
     );
 

--- a/components/PersonView/PersonView.jsx
+++ b/components/PersonView/PersonView.jsx
@@ -40,7 +40,7 @@ const PersonView = ({ personId, expandView, children }) => {
                 </h1>
               )}
               <PersonDetails {...person} expandView={expandView} />
-              {children}
+              {typeof children === 'function' ? children(person) : children}
             </>
           )}
         </>
@@ -52,7 +52,7 @@ const PersonView = ({ personId, expandView, children }) => {
 PersonView.propTypes = {
   expandView: PropTypes.bool,
   personId: PropTypes.string.isRequired,
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 };
 
 export default PersonView;

--- a/components/PersonView/PersonView.spec.jsx
+++ b/components/PersonView/PersonView.spec.jsx
@@ -22,6 +22,7 @@ describe('PersonView component', () => {
     personId: '44000000',
     expandView: false,
   };
+
   it('should render properly', async () => {
     const { getByText, queryByText } = render(<PersonView {...props} />);
     await waitFor(() => {
@@ -38,5 +39,19 @@ describe('PersonView component', () => {
       expect(getByText('Expand view')).toBeInTheDocument();
     });
     expect(queryByText('11/13/2020')).not.toBeInTheDocument();
+  });
+
+  it('should render properly with node children', async () => {
+    const { findByText } = render(<PersonView {...props}>foo</PersonView>);
+    const children = await findByText('foo');
+    expect(children).toBeDefined();
+  });
+
+  it('should render properly with func children', async () => {
+    const { findByText } = render(
+      <PersonView {...props}>{(person) => `foo${person.firstName}`}</PersonView>
+    );
+    const children = await findByText('fooCiasom');
+    expect(children).toBeDefined();
   });
 });

--- a/pages/people/[id]/records.jsx
+++ b/pages/people/[id]/records.jsx
@@ -15,10 +15,14 @@ const CasesPage = () => {
         Add a new record for
       </h1>
       <PersonView personId={query.id} expandView={true} nameSize="m">
-        <p className="govuk-label govuk-!-margin-top-7 govuk-!-margin-bottom-5">
-          Use forms to create a new record for a person
-        </p>
-        <AddForm id={query.id} />
+        {(person) => (
+          <>
+            <p className="govuk-label govuk-!-margin-top-7 govuk-!-margin-bottom-5">
+              Use forms to create a new record for a person
+            </p>
+            <AddForm person={person} />
+          </>
+        )}
       </PersonView>
     </>
   );


### PR DESCRIPTION
**What**  

- removed `getResident` from `AddForm` and passed it down from `PersonView`
- `PersonView` supports children as `node` and `func` (with render prop)

**Details**

At the moment the `AddForm` component is waiting that the `getPerson` in `PersonView` is finished to rerun the same call. We can show the `AddForm` component as soon as the first call is completed.
<img width="743" alt="Screenshot 2021-02-03 at 18 22 07" src="https://user-images.githubusercontent.com/435399/106791399-27263200-6655-11eb-8bd6-03c75f334cae.png">

**How to test it?**

- check that `/people/:id/records` is working properly