### PR TITLE
extracted allocation logic in stand alone pages

### DIFF
--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
 import { useForm } from 'react-hook-form';
 
 import { Radios } from 'components/Form';
 import Button from 'components/Button/Button';
-import Modal from 'components/Modal/Modal';
 import Spinner from 'components/Spinner/Spinner';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { useAuth } from 'components/UserContext/UserContext';
@@ -14,18 +14,14 @@ import {
   addAllocatedWorker,
 } from 'utils/api/allocatedWorkers';
 
-const AddAllocatedWorker = ({
-  personId,
-  currentlyAllocated,
-  onAddNewAllocation,
-}) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+const AddAllocatedWorker = ({ personId }) => {
   const [workersLoading, setWorkersLoading] = useState(false);
   const [teams, setTeams] = useState();
   const [workers, setWorkers] = useState();
   const [error, setError] = useState();
   const [postError, setPostError] = useState();
   const [postLoading, setPostLoading] = useState();
+  const { push } = useRouter();
   const { handleSubmit, register, watch } = useForm({
     mode: 'onChange',
   });
@@ -58,10 +54,6 @@ const AddAllocatedWorker = ({
   useEffect(() => {
     setPostError();
   }, [formValues.team, formValues.worker]);
-  const closeModal = useCallback(() => {
-    setIsModalOpen(false);
-    setWorkers();
-  });
   const addWorker = useCallback(async ({ worker }) => {
     setPostLoading(true);
     setPostError();
@@ -70,146 +62,110 @@ const AddAllocatedWorker = ({
         allocatedBy: user.email,
         allocatedWorkerId: worker,
       });
-      onAddNewAllocation();
-      closeModal();
+      push(`/people/${personId}`);
     } catch (e) {
       setPostError(true);
     }
     setPostLoading(false);
   });
+  if (error) {
+    return <ErrorMessage label="Oops an error occurred" />;
+  }
   return (
-    <>
-      <div className="lbh-table-header">
-        <h3 className="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0">
-          ALLOCATED WORKER {currentlyAllocated + 1}
-        </h3>
-        <Button
-          label="Allocate worker"
-          isSecondary
-          onClick={() => setIsModalOpen(true)}
+    <form role="form" onSubmit={handleSubmit(addWorker)}>
+      {teams && (
+        <Radios
+          name="team"
+          label="Select a team to view workers for that team"
+          labelSize="m"
+          options={teams.map(({ id, name }) => ({
+            value: id,
+            text: name,
+          }))}
+          register={register({ required: true })}
         />
-      </div>
-      <hr className="govuk-divider" />
-      <p>
-        <i>{currentlyAllocated === 0 ? 'Currently unallocated' : 'Optional'}</i>
-      </p>
-      <Modal isOpen={isModalOpen} onRequestClose={closeModal}>
-        <h1>Allocate worker</h1>
-        <form role="form" onSubmit={handleSubmit(addWorker)}>
-          {error ? (
-            <ErrorMessage label="Oops an error occurred" />
-          ) : (
-            <>
-              {teams && (
-                <Radios
-                  name="team"
-                  label="Select a team to view workers for that team"
-                  labelSize="m"
-                  options={teams.map(({ id, name }) => ({
-                    value: id,
-                    text: name,
-                  }))}
-                  register={register({ required: true })}
-                />
-              )}
-              {workers && (
-                <>
-                  <h2>
-                    {
-                      teams.find(({ id }) => id.toString() === formValues.team)
-                        ?.name
-                    }{' '}
-                    workers
-                  </h2>
-                  <p className="govuk-body">
-                    Select a worker to allocate a case to them. You can view
-                    more about a worker’s current allocated cases by selecting
-                    their name.
-                  </p>
-                  <table className="govuk-table">
-                    <thead className="govuk-table__head">
-                      <tr className="govuk-table__row">
-                        <th
-                          scope="col"
-                          className="govuk-table__header"
-                          style={{ width: '4rem' }}
-                        >
-                          Select
-                        </th>
-                        <th scope="col" className="govuk-table__header">
-                          Name
-                        </th>
-                        <th
-                          scope="col"
-                          className="govuk-table__header govuk-table__header--numeric"
-                        >
-                          Total Cases
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="govuk-table__body">
-                      {workers.map(
-                        ({ firstName, lastName, id, allocationCount }) => (
-                          <tr
-                            className="govuk-table__row govuk-radios"
-                            key={id}
-                          >
-                            <td className="govuk-table__cell">
-                              <div className="govuk-radios__item">
-                                <input
-                                  aria-labelledby={`worker_${id}`}
-                                  className="govuk-radios__input"
-                                  name="worker"
-                                  type="radio"
-                                  value={id}
-                                  disabled={workersLoading}
-                                  ref={register}
-                                />
-                                <label className="govuk-label govuk-radios__label"></label>
-                              </div>
-                            </td>
-                            <td className="govuk-table__cell lbh-table__cell--va-middle">
-                              <a
-                                id={`worker_${id}`}
-                                href={`/workers/${id}`}
-                                className="govuk-link"
-                                rel="noopener"
-                                target="_blank"
-                              >
-                                {firstName} {lastName}
-                              </a>
-                            </td>
-                            <td className="govuk-table__cell govuk-table__cell--numeric">
-                              {allocationCount}
-                            </td>
-                          </tr>
-                        )
-                      )}
-                    </tbody>
-                  </table>
-                  <Button
-                    label="Allocate worker"
-                    type="submit"
-                    disabled={postLoading}
-                  />
-                  {postError && (
-                    <ErrorMessage label="There was an error allocating the worker. Please retry." />
-                  )}
-                </>
-              )}
-              {formValues.team && (!teams || !workers) && <Spinner />}
-            </>
+      )}
+      {workers && (
+        <>
+          <h2>
+            {teams.find(({ id }) => id.toString() === formValues.team)?.name}{' '}
+            workers
+          </h2>
+          <p className="govuk-body">
+            Select a worker to allocate a case to them. You can view more about
+            a worker’s current allocated cases by selecting their name.
+          </p>
+          <table className="govuk-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th
+                  scope="col"
+                  className="govuk-table__header"
+                  style={{ width: '4rem' }}
+                >
+                  Select
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Name
+                </th>
+                <th
+                  scope="col"
+                  className="govuk-table__header govuk-table__header--numeric"
+                >
+                  Total Cases
+                </th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {workers.map(({ firstName, lastName, id, allocationCount }) => (
+                <tr className="govuk-table__row govuk-radios" key={id}>
+                  <td className="govuk-table__cell">
+                    <div className="govuk-radios__item">
+                      <input
+                        aria-labelledby={`worker_${id}`}
+                        className="govuk-radios__input"
+                        name="worker"
+                        type="radio"
+                        value={id}
+                        disabled={workersLoading}
+                        ref={register}
+                      />
+                      <label className="govuk-label govuk-radios__label"></label>
+                    </div>
+                  </td>
+                  <td className="govuk-table__cell lbh-table__cell--va-middle">
+                    <a
+                      id={`worker_${id}`}
+                      href={`/workers/${id}`}
+                      className="govuk-link"
+                    >
+                      {firstName} {lastName}
+                    </a>
+                  </td>
+                  <td className="govuk-table__cell govuk-table__cell--numeric">
+                    {allocationCount}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <Button
+            label="Allocate worker"
+            type="submit"
+            disabled={postLoading}
+          />
+          {postError && (
+            <ErrorMessage label="There was an error allocating the worker. Please retry." />
           )}
-        </form>
-      </Modal>
-    </>
+        </>
+      )}
+      {formValues.team && (!teams || !workers) && <Spinner />}
+    </form>
   );
 };
 
 AddAllocatedWorker.propTypes = {
   personId: PropTypes.string.isRequired,
-  currentlyAllocated: PropTypes.number.isRequired,
-  onAddNewAllocation: PropTypes.func.isRequired,
 };
 
 export default AddAllocatedWorker;

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.jsx
@@ -9,6 +9,13 @@ import {
   addAllocatedWorker,
 } from 'utils/api/allocatedWorkers';
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    asPath: 'path',
+    push: jest.fn(),
+  }),
+}));
+
 jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
 jest.mock('utils/api/allocatedWorkers', () => ({
@@ -37,9 +44,7 @@ describe(`AddAllocatedWorker`, () => {
     })
   );
   const props = {
-    currentlyAllocated: 3,
     personId: '123',
-    onAddNewAllocation: jest.fn(),
   };
 
   it('should render properly', async () => {
@@ -52,8 +57,6 @@ describe(`AddAllocatedWorker`, () => {
         <AddAllocatedWorker {...props} type="people" />
       </UserContext.Provider>
     );
-    const showModalButton = getByText('Allocate worker');
-    fireEvent.click(showModalButton);
     const teamRadio = await findByText(
       'Select a team to view workers for that team'
     );
@@ -66,7 +69,7 @@ describe(`AddAllocatedWorker`, () => {
   });
 
   it('should post correctly properly to the API', async () => {
-    const { getByText, getByLabelText, getByRole } = render(
+    const { findByText, getByLabelText, getByRole } = render(
       <UserContext.Provider
         value={{
           user: { name: 'foo', email: 'foo@bar.com' },
@@ -75,9 +78,7 @@ describe(`AddAllocatedWorker`, () => {
         <AddAllocatedWorker {...props} type="people" />
       </UserContext.Provider>
     );
-    await act(async () => {
-      fireEvent.click(getByText('Allocate worker'));
-    });
+    await findByText('Select a team to view workers for that team');
     await act(async () => {
       fireEvent.click(getByLabelText('Team 3'));
     });
@@ -86,7 +87,6 @@ describe(`AddAllocatedWorker`, () => {
       fireEvent.submit(getByRole('form'));
     });
     expect(addAllocatedWorker).toHaveBeenCalled();
-    expect(props.onAddNewAllocation).toHaveBeenCalled();
     expect(addAllocatedWorker).toHaveBeenCalledWith('123', {
       allocatedBy: 'foo@bar.com',
       allocatedWorkerId: 'c',

--- a/components/AllocatedWorkers/AddAllocatedWorker/__snapshots__/AddAllocatedWorker.spec.jsx.snap
+++ b/components/AllocatedWorkers/AddAllocatedWorker/__snapshots__/AddAllocatedWorker.spec.jsx.snap
@@ -2,277 +2,234 @@
 
 exports[`AddAllocatedWorker should render properly 1`] = `
 <DocumentFragment>
-  <div
-    class="lbh-table-header"
+  <form
+    role="form"
   >
-    <h3
-      class="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0"
+    <div
+      class="govuk-form-group"
     >
-      ALLOCATED WORKER 4
-    </h3>
+      <label
+        class="govuk-label govuk-label--m"
+        for="team"
+      >
+        Select a team to view workers for that team 
+      </label>
+      <div
+        class="govuk-radios"
+      >
+        <div
+          class="govuk-radios__item"
+        >
+          <input
+            class="govuk-radios__input"
+            id="team_1"
+            name="team"
+            type="radio"
+            value="1"
+          />
+          <label
+            class="govuk-label govuk-radios__label"
+            for="team_1"
+          >
+            Team 1
+          </label>
+        </div>
+        <div
+          class="govuk-radios__item"
+        >
+          <input
+            class="govuk-radios__input"
+            id="team_2"
+            name="team"
+            type="radio"
+            value="2"
+          />
+          <label
+            class="govuk-label govuk-radios__label"
+            for="team_2"
+          >
+            Team 2
+          </label>
+        </div>
+        <div
+          class="govuk-radios__item"
+        >
+          <input
+            class="govuk-radios__input"
+            id="team_3"
+            name="team"
+            type="radio"
+            value="3"
+          />
+          <label
+            class="govuk-label govuk-radios__label"
+            for="team_3"
+          >
+            Team 3
+          </label>
+        </div>
+      </div>
+    </div>
+    <h2>
+      Team 1 workers
+    </h2>
+    <p
+      class="govuk-body"
+    >
+      Select a worker to allocate a case to them. You can view more about a worker’s current allocated cases by selecting their name.
+    </p>
+    <table
+      class="govuk-table"
+    >
+      <thead
+        class="govuk-table__head"
+      >
+        <tr
+          class="govuk-table__row"
+        >
+          <th
+            class="govuk-table__header"
+            scope="col"
+            style="width: 4rem;"
+          >
+            Select
+          </th>
+          <th
+            class="govuk-table__header"
+            scope="col"
+          >
+            Name
+          </th>
+          <th
+            class="govuk-table__header govuk-table__header--numeric"
+            scope="col"
+          >
+            Total Cases
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="govuk-table__body"
+      >
+        <tr
+          class="govuk-table__row govuk-radios"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                aria-labelledby="worker_a"
+                class="govuk-radios__input"
+                name="worker"
+                type="radio"
+                value="a"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+              />
+            </div>
+          </td>
+          <td
+            class="govuk-table__cell lbh-table__cell--va-middle"
+          >
+            <a
+              class="govuk-link"
+              href="/workers/a"
+              id="worker_a"
+            >
+              Worker A
+            </a>
+          </td>
+          <td
+            class="govuk-table__cell govuk-table__cell--numeric"
+          >
+            3
+          </td>
+        </tr>
+        <tr
+          class="govuk-table__row govuk-radios"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                aria-labelledby="worker_b"
+                class="govuk-radios__input"
+                name="worker"
+                type="radio"
+                value="b"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+              />
+            </div>
+          </td>
+          <td
+            class="govuk-table__cell lbh-table__cell--va-middle"
+          >
+            <a
+              class="govuk-link"
+              href="/workers/b"
+              id="worker_b"
+            >
+              Worker B
+            </a>
+          </td>
+          <td
+            class="govuk-table__cell govuk-table__cell--numeric"
+          />
+        </tr>
+        <tr
+          class="govuk-table__row govuk-radios"
+        >
+          <td
+            class="govuk-table__cell"
+          >
+            <div
+              class="govuk-radios__item"
+            >
+              <input
+                aria-labelledby="worker_c"
+                class="govuk-radios__input"
+                name="worker"
+                type="radio"
+                value="c"
+              />
+              <label
+                class="govuk-label govuk-radios__label"
+              />
+            </div>
+          </td>
+          <td
+            class="govuk-table__cell lbh-table__cell--va-middle"
+          >
+            <a
+              class="govuk-link"
+              href="/workers/c"
+              id="worker_c"
+            >
+              Worker C
+            </a>
+          </td>
+          <td
+            class="govuk-table__cell govuk-table__cell--numeric"
+          />
+        </tr>
+      </tbody>
+    </table>
     <button
-      class="govuk-button govuk-button--secondary"
+      class="govuk-button"
       data-module="govuk-button"
+      type="submit"
     >
       Allocate worker
     </button>
-  </div>
-  <hr
-    class="govuk-divider"
-  />
-  <p>
-    <i>
-      Optional
-    </i>
-  </p>
-  <div
-    class="modal"
-  >
-    <button
-      class="closeButton"
-    >
-      MockedCloseButton
-    </button>
-    <div>
-      <h1>
-        Allocate worker
-      </h1>
-      <form
-        role="form"
-      >
-        <div
-          class="govuk-form-group"
-        >
-          <label
-            class="govuk-label govuk-label--m"
-            for="team"
-          >
-            Select a team to view workers for that team 
-          </label>
-          <div
-            class="govuk-radios"
-          >
-            <div
-              class="govuk-radios__item"
-            >
-              <input
-                class="govuk-radios__input"
-                id="team_1"
-                name="team"
-                type="radio"
-                value="1"
-              />
-              <label
-                class="govuk-label govuk-radios__label"
-                for="team_1"
-              >
-                Team 1
-              </label>
-            </div>
-            <div
-              class="govuk-radios__item"
-            >
-              <input
-                class="govuk-radios__input"
-                id="team_2"
-                name="team"
-                type="radio"
-                value="2"
-              />
-              <label
-                class="govuk-label govuk-radios__label"
-                for="team_2"
-              >
-                Team 2
-              </label>
-            </div>
-            <div
-              class="govuk-radios__item"
-            >
-              <input
-                class="govuk-radios__input"
-                id="team_3"
-                name="team"
-                type="radio"
-                value="3"
-              />
-              <label
-                class="govuk-label govuk-radios__label"
-                for="team_3"
-              >
-                Team 3
-              </label>
-            </div>
-          </div>
-        </div>
-        <h2>
-          Team 1 workers
-        </h2>
-        <p
-          class="govuk-body"
-        >
-          Select a worker to allocate a case to them. You can view more about a worker’s current allocated cases by selecting their name.
-        </p>
-        <table
-          class="govuk-table"
-        >
-          <thead
-            class="govuk-table__head"
-          >
-            <tr
-              class="govuk-table__row"
-            >
-              <th
-                class="govuk-table__header"
-                scope="col"
-                style="width: 4rem;"
-              >
-                Select
-              </th>
-              <th
-                class="govuk-table__header"
-                scope="col"
-              >
-                Name
-              </th>
-              <th
-                class="govuk-table__header govuk-table__header--numeric"
-                scope="col"
-              >
-                Total Cases
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            class="govuk-table__body"
-          >
-            <tr
-              class="govuk-table__row govuk-radios"
-            >
-              <td
-                class="govuk-table__cell"
-              >
-                <div
-                  class="govuk-radios__item"
-                >
-                  <input
-                    aria-labelledby="worker_a"
-                    class="govuk-radios__input"
-                    name="worker"
-                    type="radio"
-                    value="a"
-                  />
-                  <label
-                    class="govuk-label govuk-radios__label"
-                  />
-                </div>
-              </td>
-              <td
-                class="govuk-table__cell lbh-table__cell--va-middle"
-              >
-                <a
-                  class="govuk-link"
-                  href="/workers/a"
-                  id="worker_a"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  Worker A
-                </a>
-              </td>
-              <td
-                class="govuk-table__cell govuk-table__cell--numeric"
-              >
-                3
-              </td>
-            </tr>
-            <tr
-              class="govuk-table__row govuk-radios"
-            >
-              <td
-                class="govuk-table__cell"
-              >
-                <div
-                  class="govuk-radios__item"
-                >
-                  <input
-                    aria-labelledby="worker_b"
-                    class="govuk-radios__input"
-                    name="worker"
-                    type="radio"
-                    value="b"
-                  />
-                  <label
-                    class="govuk-label govuk-radios__label"
-                  />
-                </div>
-              </td>
-              <td
-                class="govuk-table__cell lbh-table__cell--va-middle"
-              >
-                <a
-                  class="govuk-link"
-                  href="/workers/b"
-                  id="worker_b"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  Worker B
-                </a>
-              </td>
-              <td
-                class="govuk-table__cell govuk-table__cell--numeric"
-              />
-            </tr>
-            <tr
-              class="govuk-table__row govuk-radios"
-            >
-              <td
-                class="govuk-table__cell"
-              >
-                <div
-                  class="govuk-radios__item"
-                >
-                  <input
-                    aria-labelledby="worker_c"
-                    class="govuk-radios__input"
-                    name="worker"
-                    type="radio"
-                    value="c"
-                  />
-                  <label
-                    class="govuk-label govuk-radios__label"
-                  />
-                </div>
-              </td>
-              <td
-                class="govuk-table__cell lbh-table__cell--va-middle"
-              >
-                <a
-                  class="govuk-link"
-                  href="/workers/c"
-                  id="worker_c"
-                  rel="noopener"
-                  target="_blank"
-                >
-                  Worker C
-                </a>
-              </td>
-              <td
-                class="govuk-table__cell govuk-table__cell--numeric"
-              />
-            </tr>
-          </tbody>
-        </table>
-        <button
-          class="govuk-button"
-          data-module="govuk-button"
-          type="submit"
-        >
-          Allocate worker
-        </button>
-      </form>
-    </div>
-  </div>
+  </form>
 </DocumentFragment>
 `;

--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
 
 import AllocatedWorkersTable from 'components/AllocatedWorkers/AllocatedWorkersTable';
-import AddAllocatedWorker from 'components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import { getAllocatedWorkers } from 'utils/api/allocatedWorkers';
 import Spinner from 'components/Spinner/Spinner';
+import Button from 'components/Button/Button';
 import { useAuth } from 'components/UserContext/UserContext';
 
 const AllocatedWorkers = ({ id }) => {
@@ -24,6 +25,7 @@ const AllocatedWorkers = ({ id }) => {
   useEffect(() => {
     getWorkers();
   }, []);
+  const { asPath } = useRouter();
   const { user } = useAuth();
   if (loading) {
     return <Spinner />;
@@ -37,11 +39,24 @@ const AllocatedWorkers = ({ id }) => {
         />
       )}
       {user.hasAllocationsPermissions && (
-        <AddAllocatedWorker
-          personId={id}
-          currentlyAllocated={allocWorkers.length}
-          onAddNewAllocation={getWorkers}
-        />
+        <div>
+          <div className="lbh-table-header">
+            <h3 className="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0">
+              ALLOCATED WORKER {allocWorkers.length + 1}
+            </h3>
+            <Button
+              label="Allocate worker"
+              isSecondary
+              route={`${asPath}/allocations/add`}
+            />
+          </div>
+          <hr className="govuk-divider" />
+          <p>
+            <i>
+              {allocWorkers.length === 0 ? 'Currently unallocated' : 'Optional'}
+            </i>
+          </p>
+        </div>
       )}
       {error && <ErrorMessage />}
     </div>

--- a/components/AllocatedWorkers/AllocatedWorkers.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.jsx
@@ -35,7 +35,7 @@ const AllocatedWorkers = ({ id }) => {
       {allocWorkers && (
         <AllocatedWorkersTable
           records={allocWorkers}
-          updateWorkers={getWorkers}
+          hasAllocationsPermissions={user.hasAllocationsPermissions}
         />
       )}
       {user.hasAllocationsPermissions && (

--- a/components/AllocatedWorkers/AllocatedWorkers.spec.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkers.spec.jsx
@@ -5,6 +5,13 @@ import AllocatedWorkers from './AllocatedWorkers';
 
 import { getAllocatedWorkers } from 'utils/api/allocatedWorkers';
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    asPath: 'path',
+    push: jest.fn(),
+  }),
+}));
+
 jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
 jest.mock('utils/api/allocatedWorkers', () => ({
@@ -14,10 +21,6 @@ jest.mock('utils/api/allocatedWorkers', () => ({
 jest.mock('components/AllocatedWorkers/AllocatedWorkersTable', () => () => (
   <div>MockedAllocatedWorkersTable</div>
 ));
-jest.mock(
-  'components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker',
-  () => () => <div>MockedAddAllocatedWorkers</div>
-);
 
 describe(`AddAllocatedWorker`, () => {
   getAllocatedWorkers.mockImplementation(() =>
@@ -34,7 +37,7 @@ describe(`AddAllocatedWorker`, () => {
     id: '123',
   };
 
-  it('should render only the table if not admin', async () => {
+  it('should render only the table if not allocator', async () => {
     const { findByText, queryByText } = render(
       <UserContext.Provider
         value={{
@@ -46,11 +49,11 @@ describe(`AddAllocatedWorker`, () => {
     );
     const allocateTable = await findByText('MockedAllocatedWorkersTable');
     expect(allocateTable).toBeInTheDocument();
-    const addAllocate = await queryByText('MockedAddAllocatedWorkers');
+    const addAllocate = await queryByText('Allocate worker');
     expect(addAllocate).not.toBeInTheDocument();
   });
 
-  it('should render everything if admin', async () => {
+  it('should render everything if allocator', async () => {
     const { findByText, queryByText } = render(
       <UserContext.Provider
         value={{
@@ -66,7 +69,7 @@ describe(`AddAllocatedWorker`, () => {
     );
     const allocateTable = await findByText('MockedAllocatedWorkersTable');
     expect(allocateTable).toBeInTheDocument();
-    const addAllocate = await queryByText('MockedAddAllocatedWorkers');
+    const addAllocate = await queryByText('Allocate worker');
     expect(addAllocate).toBeInTheDocument();
   });
 });

--- a/components/AllocatedWorkers/AllocatedWorkersTable.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkersTable.jsx
@@ -1,10 +1,7 @@
-import { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
 
-import Modal from 'components/Modal/Modal';
 import Button from 'components/Button/Button';
-import DeallocatedWorkersDetails from './DeallocateWorkerDetails/DeallocatedWorkerDetails';
-import { useAuth } from 'components/UserContext/UserContext';
 
 const AllocatedWorkersEntry = ({
   allocatedWorkerTeam,
@@ -13,85 +10,72 @@ const AllocatedWorkersEntry = ({
   allocationEndDate,
   workerType,
   index,
-  openModal,
-}) => {
-  const { user } = useAuth();
-  return (
-    <>
-      <div className="lbh-table-header">
-        <h3 className="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0">
-          Allocated Worker {index + 1}
-        </h3>
-        {user.hasAllocationsPermissions && (
-          <Button isSecondary label="Deallocate Worker" onClick={openModal} />
-        )}
-      </div>
-      <hr className="govuk-divider" />
-      <div></div>
-      <dl className="govuk-summary-list">
-        {allocatedWorker && (
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">Allocated Worker:</dt>
-            <dd className="govuk-summary-list__value">{allocatedWorker}</dd>
-          </div>
-        )}
-        {allocatedWorkerTeam && (
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">Allocated Team</dt>
-            <dd className="govuk-summary-list__value">{allocatedWorkerTeam}</dd>
-          </div>
-        )}
-        {workerType && (
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">Role</dt>
-            <dd className="govuk-summary-list__value">{workerType}</dd>
-          </div>
-        )}
-        {allocationStartDate && (
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">Start Date</dt>
-            <dd className="govuk-summary-list__value">
-              {new Date(allocationStartDate).toLocaleDateString('en-GB')}
-            </dd>
-          </div>
-        )}
-        {allocationEndDate && (
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">End Date</dt>
-            <dd className="govuk-summary-list__value">
-              {new Date(allocationEndDate).toLocaleDateString('en-GB')}
-            </dd>
-          </div>
-        )}
-      </dl>
-    </>
-  );
-};
-const AllocatedWorkersTable = ({ records, updateWorkers }) => {
-  const [selectedWorker, setSelectedWorker] = useState();
+  showDeallocateButton,
+  deallocationUrl,
+}) => (
+  <>
+    <div className="lbh-table-header">
+      <h3 className="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0">
+        Allocated Worker {index + 1}
+      </h3>
+      {showDeallocateButton && (
+        <Button isSecondary label="Deallocate Worker" route={deallocationUrl} />
+      )}
+    </div>
+    <hr className="govuk-divider" />
+    <div></div>
+    <dl className="govuk-summary-list">
+      {allocatedWorker && (
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">Allocated Worker:</dt>
+          <dd className="govuk-summary-list__value">{allocatedWorker}</dd>
+        </div>
+      )}
+      {allocatedWorkerTeam && (
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">Allocated Team</dt>
+          <dd className="govuk-summary-list__value">{allocatedWorkerTeam}</dd>
+        </div>
+      )}
+      {workerType && (
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">Role</dt>
+          <dd className="govuk-summary-list__value">{workerType}</dd>
+        </div>
+      )}
+      {allocationStartDate && (
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">Start Date</dt>
+          <dd className="govuk-summary-list__value">
+            {new Date(allocationStartDate).toLocaleDateString('en-GB')}
+          </dd>
+        </div>
+      )}
+      {allocationEndDate && (
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">End Date</dt>
+          <dd className="govuk-summary-list__value">
+            {new Date(allocationEndDate).toLocaleDateString('en-GB')}
+          </dd>
+        </div>
+      )}
+    </dl>
+  </>
+);
+
+const AllocatedWorkersTable = ({ records, hasAllocationsPermissions }) => {
+  const { asPath } = useRouter();
   return (
     <div>
-      {records.map((result, index) => (
+      {records.map((record, index) => (
         <AllocatedWorkersEntry
-          key={index}
+          key={record.id}
           index={index}
-          openModal={() => setSelectedWorker(index)}
-          {...result}
+          showDeallocateButton={hasAllocationsPermissions}
+          deallocationUrl={`${asPath}/allocations/${record.id}/remove`}
+          {...record}
         />
       ))}
-      <Modal
-        isOpen={Boolean(selectedWorker !== undefined)}
-        onRequestClose={() => setSelectedWorker()}
-      >
-        <DeallocatedWorkersDetails
-          {...records[selectedWorker]}
-          isLastWorker={records.length === 1}
-          onDeallocation={() => {
-            updateWorkers();
-            setSelectedWorker();
-          }}
-        ></DeallocatedWorkersDetails>
-      </Modal>
     </div>
   );
 };
@@ -108,7 +92,7 @@ AllocatedWorkersTable.propTypes = {
       personId: PropTypes.number.isRequired,
     })
   ).isRequired,
-  updateWorkers: PropTypes.func.isRequired,
+  hasAllocationsPermissions: PropTypes.bool.isRequired,
 };
 
 export default AllocatedWorkersTable;

--- a/components/AllocatedWorkers/AllocatedWorkersTable.spec.jsx
+++ b/components/AllocatedWorkers/AllocatedWorkersTable.spec.jsx
@@ -2,6 +2,12 @@ import { render } from '@testing-library/react';
 import { UserContext } from 'components/UserContext/UserContext';
 import AllocatedWorkersTable from './AllocatedWorkersTable';
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    asPath: 'path',
+  }),
+}));
+
 describe('AllocatedWorkers component', () => {
   const props = {
     records: [
@@ -15,8 +21,9 @@ describe('AllocatedWorkers component', () => {
         personId: 1234,
       },
     ],
-    updateWorkers: jest.fn(),
+    hasAllocationsPermissions: false,
   };
+
   it('should render properly', () => {
     const { asFragment } = render(
       <UserContext.Provider
@@ -25,6 +32,19 @@ describe('AllocatedWorkers component', () => {
         }}
       >
         <AllocatedWorkersTable {...props} />
+      </UserContext.Provider>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render properly - with deallocate button', () => {
+    const { asFragment } = render(
+      <UserContext.Provider
+        value={{
+          user: { name: 'foo' },
+        }}
+      >
+        <AllocatedWorkersTable {...props} hasAllocationsPermissions={true} />
       </UserContext.Provider>
     );
     expect(asFragment()).toMatchSnapshot();

--- a/components/AllocatedWorkers/__snapshots__/AllocatedWorkersTable.spec.jsx.snap
+++ b/components/AllocatedWorkers/__snapshots__/AllocatedWorkersTable.spec.jsx.snap
@@ -1,5 +1,105 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AllocatedWorkers component should render properly - with deallocate button 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="lbh-table-header"
+    >
+      <h3
+        class="govuk-fieldset__legend--m govuk-custom-text-color govuk-!-margin-top-0"
+      >
+        Allocated Worker 1
+      </h3>
+      <button
+        class="govuk-button govuk-button--secondary"
+        data-module="govuk-button"
+      >
+        Deallocate Worker
+      </button>
+    </div>
+    <hr
+      class="govuk-divider"
+    />
+    <div />
+    <dl
+      class="govuk-summary-list"
+    >
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          Allocated Worker:
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          Officer Name
+        </dd>
+      </div>
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          Allocated Team
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          Safeguarding and Reviewing Team
+        </dd>
+      </div>
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          Role
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          Consultant Social Worker
+        </dd>
+      </div>
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          Start Date
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          3/28/2019
+        </dd>
+      </div>
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          End Date
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          3/28/2019
+        </dd>
+      </div>
+    </dl>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`AllocatedWorkers component should render properly 1`] = `
 <DocumentFragment>
   <div>

--- a/pages/people/[id]/allocations/[allocationId]/remove.jsx
+++ b/pages/people/[id]/allocations/[allocationId]/remove.jsx
@@ -1,0 +1,31 @@
+import { NextSeo } from 'next-seo';
+import { useRouter } from 'next/router';
+
+import DeallocateWorkers from 'components/AllocatedWorkers/DeallocateWorker/DeallocateWorker';
+import BackButton from 'components/Layout/BackButton/BackButton';
+import PersonView from 'components/PersonView/PersonView';
+
+const CasesPage = () => {
+  const { query } = useRouter();
+  return (
+    <>
+      <NextSeo title={`#${query.id} Cases`} noindex />
+      <BackButton />
+      <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
+        Deallocate worker from
+      </h1>
+      <PersonView personId={query.id} expandView={true} nameSize="m">
+        {(person) => (
+          <div className="govuk-!-margin-top-7">
+            <DeallocateWorkers
+              personId={person.mosaicId}
+              allocationId={query.allocationId}
+            />
+          </div>
+        )}
+      </PersonView>
+    </>
+  );
+};
+
+export default CasesPage;

--- a/pages/people/[id]/allocations/add.jsx
+++ b/pages/people/[id]/allocations/add.jsx
@@ -1,0 +1,28 @@
+import { NextSeo } from 'next-seo';
+import { useRouter } from 'next/router';
+
+import AddAllocatedWorker from 'components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker';
+import BackButton from 'components/Layout/BackButton/BackButton';
+import PersonView from 'components/PersonView/PersonView';
+
+const CasesPage = () => {
+  const { query } = useRouter();
+  return (
+    <>
+      <NextSeo title={`#${query.id} Cases`} noindex />
+      <BackButton />
+      <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
+        Allocate worker to
+      </h1>
+      <PersonView personId={query.id} expandView={true} nameSize="m">
+        {(person) => (
+          <div className="govuk-!-margin-top-7">
+            <AddAllocatedWorker personId={person.mosaicId} />
+          </div>
+        )}
+      </PersonView>
+    </>
+  );
+};
+
+export default CasesPage;


### PR DESCRIPTION
- extracted add allocations in a stand alone page (`/people/:id/allocations/add`)
- extracted delete allocations in a stand alone page (`/people/:id/allocations/:allocationId/remove`)

**Note:**
- The APIs at the moment are failing, they will be addressed in a next PR when the BE will be ready
