### PR TITLE
added redirect to ssr if not authenticated

### DIFF
--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -17,7 +17,6 @@ import { useAuth } from 'components/UserContext/UserContext';
 import { getResidents } from 'utils/api/residents';
 import { getCases } from 'utils/api/cases';
 import { getQueryString } from 'utils/urls';
-import { getUserType } from 'utils/user';
 
 const getRecords = (data) => [
   ...(data.residents || []),
@@ -84,7 +83,7 @@ const Search = ({ type }) => {
   useEffect(() => {
     Object.keys(query).length && onSearch(query);
   }, [query]);
-  const addNewPerson = type === 'people' && getUserType(user) === 'Admin' && (
+  const addNewPerson = type === 'people' && user.hasAdminPermissions && (
     <>
       Results don't match{' '}
       <Link href="/form/create-new-person/client-details">

--- a/components/UserContext/UserContext.jsx
+++ b/components/UserContext/UserContext.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 import { useRouter } from 'next/router';
 
-import { AUTH_WHITELIST } from 'utils/auth';
+import { shouldRedirect } from 'utils/auth';
 import { isBrowser } from 'utils/ssr';
 
 export const UserContext = createContext({
@@ -9,25 +9,9 @@ export const UserContext = createContext({
   setUser: () => {},
 });
 
-const shouldRedirect = (isPathWhitelisted, user) => {
-  if (isBrowser()) {
-    if (!isPathWhitelisted) {
-      if (!user) {
-        return '/login';
-      }
-      if (!user?.isAuthorised) {
-        return '/access-denied';
-      }
-    }
-    if (isPathWhitelisted & user?.isAuthorised) {
-      return '/';
-    }
-  }
-};
-
 export const AuthProvider = ({ children, user }) => {
   const { pathname, push } = useRouter();
-  const redirect = shouldRedirect(AUTH_WHITELIST.includes(pathname), user);
+  const redirect = isBrowser() && shouldRedirect(pathname, user);
   if (redirect) {
     push(redirect);
     return <></>;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -5,7 +5,7 @@ import Layout from 'components/Layout';
 import SEO from '../next-seo.config';
 import GoogleAnalytics from 'components/GoogleAnalytics/GoogleAnalytics';
 import { AuthProvider } from 'components/UserContext/UserContext';
-import { isAuthorised } from 'utils/auth';
+import { isAuthorised, shouldRedirect } from 'utils/auth';
 
 import 'stylesheets/all.scss';
 import 'stylesheets/header.scss';
@@ -40,6 +40,13 @@ MyApp.getInitialProps = async (appContext) => {
   let user;
   if (appContext.ctx.req) {
     user = isAuthorised(appContext.ctx.req);
+    const redirect = shouldRedirect(appContext.ctx.req.url, user);
+    if (redirect) {
+      appContext.ctx.res.writeHead(302, {
+        Location: redirect,
+      });
+      appContext.ctx.res.end();
+    }
   }
   const appProps = await App.getInitialProps(appContext);
   return { ...appProps, user };

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -21,6 +21,21 @@ export const deleteSession = (res) => {
   res.end();
 };
 
+export const shouldRedirect = (pathname, user) => {
+  const isPathWhitelisted = AUTH_WHITELIST.includes(pathname);
+  if (!isPathWhitelisted) {
+    if (!user) {
+      return '/login';
+    }
+    if (!user?.isAuthorised) {
+      return '/access-denied';
+    }
+  }
+  if (isPathWhitelisted & user?.isAuthorised) {
+    return '/';
+  }
+};
+
 export const isAuthorised = (req) => {
   const {
     HACKNEY_JWT_SECRET,

--- a/utils/user.js
+++ b/utils/user.js
@@ -15,6 +15,12 @@ export const getPermissionFlag = (user) => {
   if (isOnlyChildren(user)) return 'C';
 };
 
+/**
+ * Returns the name type of the user.
+ *
+ * Note: for permission checks use `user.hasAdminPermissions` instead
+ * @param {object} user the `user` returned by the `UserContext`
+ */
 export const getUserType = (user) =>
   user &&
   (isOnlyAdult(user) ? 'Adult' : isOnlyChildren(user) ? 'Children' : 'Admin');


### PR DESCRIPTION
**What**  
A check is made on page rendering and if it's the case, redirect.
This is fixing the use of `UserContext` in not logged pages.
Used `hasAdminPermissions` instead of `getUserType` on `Search`.

Also, added documentation for `getUserType`.