### PR TITLE
pass age context to the getTeams in add allocations

### DIFF
--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.jsx
@@ -14,7 +14,7 @@ import {
   addAllocatedWorker,
 } from 'utils/api/allocatedWorkers';
 
-const AddAllocatedWorker = ({ personId }) => {
+const AddAllocatedWorker = ({ personId, ageContext }) => {
   const [postError, setPostError] = useState();
   const [postLoading, setPostLoading] = useState();
   const { query, push, replace, pathname } = useRouter();
@@ -22,7 +22,7 @@ const AddAllocatedWorker = ({ personId }) => {
     defaultValues: query,
   });
   const { user } = useAuth();
-  const { data: { teams } = {}, error: errorTeams } = getTeams();
+  const { data: { teams } = {}, error: errorTeams } = getTeams({ ageContext });
   const { data: { workers } = {}, error: errorWorkers } = getTeamWorkers(
     query?.teamId
   );
@@ -178,6 +178,7 @@ const AddAllocatedWorker = ({ personId }) => {
 
 AddAllocatedWorker.propTypes = {
   personId: PropTypes.string.isRequired,
+  ageContext: PropTypes.oneOf(['A', 'C']).isRequired,
 };
 
 export default AddAllocatedWorker;

--- a/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.jsx
+++ b/components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker.spec.jsx
@@ -46,6 +46,7 @@ describe(`AddAllocatedWorker`, () => {
   }));
   const props = {
     personId: '123',
+    ageContext: 'A',
   };
 
   it('should render properly', async () => {
@@ -55,13 +56,14 @@ describe(`AddAllocatedWorker`, () => {
           user: { name: 'foo', email: 'foo@bar.com' },
         }}
       >
-        <AddAllocatedWorker {...props} type="people" />
+        <AddAllocatedWorker {...props} />
       </UserContext.Provider>
     );
     const teamRadio = await findByText(
       'Select a team to view workers for that team'
     );
     expect(teamRadio).toBeInTheDocument();
+    expect(getTeams).toHaveBeenCalledWith({ ageContext: 'A' });
     const radioSelection = getByText('Team 1');
     await act(async () => {
       fireEvent.click(radioSelection);
@@ -76,7 +78,7 @@ describe(`AddAllocatedWorker`, () => {
           user: { name: 'foo', email: 'foo@bar.com' },
         }}
       >
-        <AddAllocatedWorker {...props} type="people" />
+        <AddAllocatedWorker {...props} />
       </UserContext.Provider>
     );
     await findByText('Select a team to view workers for that team');

--- a/pages/api/teams/index.js
+++ b/pages/api/teams/index.js
@@ -15,7 +15,7 @@ export default async (req, res) => {
     case 'GET':
       try {
         const data = await getTeams({
-          context_flag: user.permissionFlag || 'B', //TODO fix this once 'B' has been added to the BE
+          context_flag: req.query?.ageContext || user.permissionFlag || 'B', //TODO fix this once 'B' has been added to the BE
         });
         res.status(HttpStatus.OK).json(data);
       } catch (error) {

--- a/pages/people/[id]/allocations/add.jsx
+++ b/pages/people/[id]/allocations/add.jsx
@@ -17,7 +17,10 @@ const CasesPage = () => {
       <PersonView personId={query.id} expandView={true} nameSize="m">
         {(person) => (
           <div className="govuk-!-margin-top-7">
-            <AddAllocatedWorker personId={person.mosaicId} />
+            <AddAllocatedWorker
+              personId={person.mosaicId}
+              ageContext={person.ageContext}
+            />
           </div>
         )}
       </PersonView>

--- a/utils/api/allocatedWorkers.js
+++ b/utils/api/allocatedWorkers.js
@@ -4,7 +4,8 @@ import axios from 'axios';
 export const getAllocatedWorkers = (id) =>
   useSWR(`/api/residents/${id}/allocated-workers`);
 
-export const getTeams = () => useSWR(`/api/teams`);
+export const getTeams = ({ ageContext } = {}) =>
+  useSWR(`/api/teams${ageContext ? '?ageContext=' + ageContext : ''}`);
 
 export const getTeamWorkers = (teamId) =>
   useSWR(teamId ? `/api/teams/${teamId}/workers` : null);

--- a/utils/api/allocatedWorkers.spec.js
+++ b/utils/api/allocatedWorkers.spec.js
@@ -23,6 +23,12 @@ describe('allocatedWorkers APIs', () => {
       allocatedWorkersAPI.getTeams();
       expect(SWR.default).toHaveBeenCalledWith('/api/teams');
     });
+
+    it('should add ageContext if present', () => {
+      jest.spyOn(SWR, 'default');
+      allocatedWorkersAPI.getTeams({ ageContext: 'A' });
+      expect(SWR.default).toHaveBeenCalledWith('/api/teams?ageContext=A');
+    });
   });
 
   describe('getTeamWorkers', () => {


### PR DESCRIPTION
**What**  
Currently we are showing teams based on the user context, we need to show them based on the resident `ageContext` instead.

**How to test it**
- check a child resident http://dev.hackney.gov.uk:3000/people/321569/allocations/add
- check an adult resident http://dev.hackney.gov.uk:3000/people/234/allocations/add
- they need to show different teams