### PR TITLE
fall back to timestamp if no date if event

### DIFF
--- a/components/Cases/Cases.spec.jsx
+++ b/components/Cases/Cases.spec.jsx
@@ -57,7 +57,6 @@ describe('Cases component', () => {
               recordId: '12345',
               caseFormUrl: 'http//bar/bar',
               officerEmail: 'bar@bar.co.uk',
-              dateOfEvent: '2020-12-23',
               caseFormData: { form_name_overall: 'foo' },
             },
           ],

--- a/components/Cases/CasesTable.jsx
+++ b/components/Cases/CasesTable.jsx
@@ -10,10 +10,11 @@ const CasesEntry = ({
   officerEmail,
   dateOfEvent,
   caseFormData,
+  caseFormTimestamp,
 }) => (
   <tr className="govuk-table__row">
     <td className="govuk-table__cell govuk--timestamp">
-      {dateOfEvent && formatDate(dateOfEvent)}{' '}
+      {formatDate(dateOfEvent || caseFormTimestamp)}{' '}
     </td>
     <td className="govuk-table__cell">{formName}</td>
     <td className="govuk-table__cell">
@@ -46,7 +47,8 @@ CasesTable.propTypes = {
       formName: PropTypes.string.isRequired,
       caseFormUrl: PropTypes.string.isRequired,
       officerEmail: PropTypes.string.isRequired,
-      dateOfEvent: PropTypes.string.isRequired,
+      dateOfEvent: PropTypes.string,
+      caseFormTimestamp: PropTypes.string,
     })
   ).isRequired,
 };

--- a/components/Cases/__snapshots__/Cases.spec.jsx.snap
+++ b/components/Cases/__snapshots__/Cases.spec.jsx.snap
@@ -133,7 +133,7 @@ exports[`Cases component should render records properly 1`] = `
         <td
           class="govuk-table__cell govuk--timestamp"
         >
-          Jun 11, 1929 
+          Dec 23, 2020 
         </td>
         <td
           class="govuk-table__cell"
@@ -164,7 +164,7 @@ exports[`Cases component should render records properly 1`] = `
         <td
           class="govuk-table__cell govuk--timestamp"
         >
-          Jun 11, 1929 
+          Dec 4, 2020 
         </td>
         <td
           class="govuk-table__cell"

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,16 +1,30 @@
 import isValid from 'date-fns/isValid';
 
+const EU_DATE = /^(\d{2})[/|-](\d{2})[/|-](\d{4})/;
+const US_DATE = /^(\d{4})[/|-](\d{2})[/|-](\d{2})/;
+
 export const parseDate = (date) => {
-  const split = date.split(/[/-\s]/).map((digit) => parseInt(digit, 10));
-  return new Date(split[2], split[1] - 1, split[0]);
+  const dateEU = EU_DATE.exec(date);
+  if (dateEU) {
+    return new Date(dateEU[3], parseInt(dateEU[2], 10) - 1, dateEU[1]);
+  }
+  const dateUS = US_DATE.exec(date);
+  if (dateUS) {
+    return new Date(dateUS[1], parseInt(dateUS[2], 10) - 1, dateUS[3]);
+  }
 };
 
-export const formatDate = (date) =>
-  parseDate(date).toLocaleString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
+export const formatDate = (date) => {
+  const parsedDate = parseDate(date);
+  return (
+    parsedDate &&
+    parsedDate.toLocaleString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    })
+  );
+};
 
 export const isDateValid = (date) => Boolean(date) && isValid(parseDate(date));
 

--- a/utils/date.spec.js
+++ b/utils/date.spec.js
@@ -11,6 +11,12 @@ describe('date util', () => {
   describe('parseDate', () => {
     it('should work properly', () => {
       expect(parseDate('22/09/1941')).toEqual(new Date(1941, 8, 22));
+      expect(parseDate('22/01/2021 10:46:42')).toEqual(new Date(2021, 0, 22));
+      expect(parseDate('2000-12-12')).toEqual(new Date(2000, 11, 12));
+      expect(parseDate('2021-01-19T16:28:54.1295896Z')).toEqual(
+        new Date(2021, 0, 19)
+      );
+      expect(parseDate('-12-12')).toEqual(undefined);
     });
   });
 


### PR DESCRIPTION
**What**
- improved sanitisation of the date
  supported syntax:
```
22/09/1941
22/01/2021 10:46:42
2000-12-12
2021-01-19T16:28:54.1295896Z
```
- fallback to `caseFormTimestamp` if `dateOfEvent` is not present

<img width="1000" alt="Screenshot 2021-02-16 at 12 29 19" src="https://user-images.githubusercontent.com/435399/108063481-93446500-705b-11eb-9ce4-778c1d5c8021.png">

It's not ideal using regex for extract dates but until the BE is not fixing this it's good enough.

