### PR TITLE
properly show the allocation/deallocation page, based on the record

### DIFF
--- a/components/AllocatedWorkers/AllocationRecap/AllocationRecap.jsx
+++ b/components/AllocatedWorkers/AllocationRecap/AllocationRecap.jsx
@@ -21,7 +21,8 @@ const AllocationRecap = ({ personId, allocationId, recordId }) => {
   if (!allocation || !record) {
     return <Spinner />;
   }
-  const isDeallocation = allocation.caseStatus.toLowerCase() === 'closed';
+  const isDeallocation =
+    record.caseFormData.form_name_overall === 'API_Deallocation';
   return (
     <>
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">

--- a/components/AllocatedWorkers/AllocationRecap/AllocationRecap.spec.jsx
+++ b/components/AllocatedWorkers/AllocationRecap/AllocationRecap.spec.jsx
@@ -16,16 +16,6 @@ jest.mock('utils/api/cases', () => ({
 }));
 
 describe(`AllocationRecap`, () => {
-  getCaseByResident.mockImplementation(() => ({
-    data: {
-      caseFormData: {
-        form_name_overall: 'form name',
-        created_by: 'creator',
-        deallocation_reason: 'a valid reason',
-      },
-    },
-  }));
-
   const props = {
     personId: 'p_123',
     allocationId: 'a_123',
@@ -33,6 +23,15 @@ describe(`AllocationRecap`, () => {
   };
 
   it('should render properly on deallocation', async () => {
+    getCaseByResident.mockImplementation(() => ({
+      data: {
+        caseFormData: {
+          form_name_overall: 'API_Deallocation',
+          created_by: 'creator',
+          deallocation_reason: 'a valid reason',
+        },
+      },
+    }));
     getResidentAllocation.mockImplementation(() => ({
       data: {
         personName: 'person',
@@ -41,7 +40,6 @@ describe(`AllocationRecap`, () => {
         allocatedWorkerTeam: 'team',
         allocationStartDate: '2000-10-01',
         allocationEndDate: '2000-11-01',
-        caseStatus: 'Closed',
       },
     }));
     const { asFragment } = render(<AllocationRecap {...props} />);
@@ -51,6 +49,15 @@ describe(`AllocationRecap`, () => {
   });
 
   it('should render properly on allocation', async () => {
+    getCaseByResident.mockImplementation(() => ({
+      data: {
+        caseFormData: {
+          form_name_overall: 'API_Allocation',
+          created_by: 'creator',
+          deallocation_reason: 'a valid reason',
+        },
+      },
+    }));
     getResidentAllocation.mockImplementation(() => ({
       data: {
         personName: 'person',
@@ -58,7 +65,6 @@ describe(`AllocationRecap`, () => {
         workerType: 'type',
         allocatedWorkerTeam: 'team',
         allocationStartDate: '2000-10-01',
-        caseStatus: 'Open',
       },
     }));
     const { asFragment } = render(<AllocationRecap {...props} />);

--- a/components/Cases/CaseLink.jsx
+++ b/components/Cases/CaseLink.jsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 
 const getLink = (recordId, { form_name_overall, ...caseFormData }) => {
   switch (form_name_overall) {
+    case 'API_Allocation':
     case 'API_Deallocation':
       return `/people/${caseFormData.mosaic_id}/allocations/${caseFormData.allocation_id}?recordId=${recordId}`;
     default:

--- a/utils/server/cases.js
+++ b/utils/server/cases.js
@@ -29,7 +29,8 @@ export const getCasesByResident = (mosaic_id, params) =>
   getCases({ mosaic_id, ...params });
 
 export const getCaseByResident = async (mosaic_id, case_id, params) => {
-  const data = await getCases({ mosaic_id, ...params });
+  // TODO: this should be covered by the BE
+  const data = await getCases({ mosaic_id, ...params, limit: 100 });
   return data.cases?.find(({ recordId }) => recordId === case_id);
 };
 


### PR DESCRIPTION
**What**  
- added possibility to view the allocation records
- fixed the `getCase` if the allocation/deallocation is not in the first 20 records returned (this is going to be fixed when the BE will release a direct get)

<img width="655" alt="Screenshot 2021-02-16 at 12 50 31" src="https://user-images.githubusercontent.com/435399/108066247-5e3a1180-705f-11eb-8841-a6dd1a511b09.png">

**How to test it**
Check http://dev.hackney.gov.uk:3000/people/33343831 as it has allocations and deallocations.
