### PR TITLE
added collapse/expand functionality to the summary component

### DIFF
--- a/components/FormWizard/FormWizard.jsx
+++ b/components/FormWizard/FormWizard.jsx
@@ -23,6 +23,7 @@ const FormWizard = ({
   hideBackButton,
   customConfirmation,
   customSummary,
+  isSummaryCollapsable = true,
 }) => {
   Router.events.on('routeChangeComplete', () => {
     window.scrollTo(0, 0);
@@ -129,6 +130,7 @@ const FormWizard = ({
           }}
           onFormSubmit={onFormSubmit}
           successMessage={successMessage}
+          isSummaryCollapsable={steps.length > 3 && isSummaryCollapsable}
         />
       </fieldset>
     </div>
@@ -148,6 +150,7 @@ FormWizard.propTypes = {
   hideBackButton: PropTypes.bool,
   onFormSubmit: PropTypes.func,
   defaultValues: PropTypes.shape({}),
+  isSummaryCollapsable: PropTypes.bool,
 };
 
 export default FormWizard;

--- a/components/Steps/Confirmation.jsx
+++ b/components/Steps/Confirmation.jsx
@@ -8,6 +8,7 @@ const ConfirmationStep = ({
   formSteps,
   formPath,
   successMessage,
+  isSummaryCollapsable,
 }) => {
   const router = useRouter();
   const { ref } = router.query;
@@ -26,7 +27,12 @@ const ConfirmationStep = ({
           </div>
         )}
       </div>
-      <Summary formData={formData} formPath={formPath} formSteps={formSteps} />
+      <Summary
+        formData={formData}
+        formPath={formPath}
+        formSteps={formSteps}
+        isSummaryCollapsable={isSummaryCollapsable}
+      />
     </div>
   );
 };
@@ -36,6 +42,7 @@ ConfirmationStep.propTypes = {
   formSteps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   formPath: PropTypes.string.isRequired,
   successMessage: PropTypes.string,
+  isSummaryCollapsable: PropTypes.bool,
 };
 
 export default ConfirmationStep;

--- a/components/Steps/Summary.jsx
+++ b/components/Steps/Summary.jsx
@@ -9,7 +9,13 @@ import ErrorSummary from 'components/ErrorSummary/ErrorSummary';
 import { filterDataOnCondition } from 'utils/steps';
 import { sanitiseObject } from 'utils/objects';
 
-const SummaryStep = ({ formData, formSteps, formPath, onFormSubmit }) => {
+const SummaryStep = ({
+  formData,
+  formSteps,
+  formPath,
+  onFormSubmit,
+  isSummaryCollapsable,
+}) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasError, setHasError] = useState(false);
   const onSubmit = async () => {
@@ -47,6 +53,7 @@ const SummaryStep = ({ formData, formSteps, formPath, onFormSubmit }) => {
         formPath={formPath}
         formSteps={formSteps}
         canEdit
+        isSummaryCollapsable={isSummaryCollapsable}
       />
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <Button
@@ -79,6 +86,7 @@ SummaryStep.propTypes = {
   formSteps: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   formPath: PropTypes.string.isRequired,
   onFormSubmit: PropTypes.func.isRequired,
+  isSummaryCollapsable: PropTypes.bool,
 };
 
 export default SummaryStep;

--- a/components/Steps/__snapshots__/Confirmation.spec.jsx.snap
+++ b/components/Steps/__snapshots__/Confirmation.spec.jsx.snap
@@ -27,11 +27,15 @@ exports[`Confirmation component should render properly 1`] = `
       <div
         class="lbh-table-header"
       >
-        <h3
-          class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+        <div
+          class="sectionTitle"
         >
-          FOO BAR
-        </h3>
+          <h3
+            class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+          >
+            FOO BAR
+          </h3>
+        </div>
       </div>
       <hr
         class="govuk-divider"

--- a/components/Steps/__snapshots__/Summary.spec.jsx.snap
+++ b/components/Steps/__snapshots__/Summary.spec.jsx.snap
@@ -18,17 +18,21 @@ exports[`Summary component should render properly 1`] = `
       <div
         class="lbh-table-header"
       >
-        <h3
-          class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+        <div
+          class="sectionTitle"
         >
-          FOO BAR
-        </h3>
-        <a
-          class="govuk-link"
-          href="/foo/bar-foofoo-bar?fromSummary=true"
-        >
-          Edit details
-        </a>
+          <h3
+            class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+          >
+            FOO BAR
+          </h3>
+          <a
+            class="govuk-link"
+            href="/foo/bar-foofoo-bar?fromSummary=true"
+          >
+            Edit
+          </a>
+        </div>
       </div>
       <hr
         class="govuk-divider"

--- a/components/Summary/Summary.jsx
+++ b/components/Summary/Summary.jsx
@@ -113,6 +113,9 @@ SummarySection.propTypes = {
   ).isRequired,
   formPath: PropTypes.string.isRequired,
   canEdit: PropTypes.bool,
+  collapsedSection: PropTypes.object.isRequired,
+  toggleCollapsed: PropTypes.func.isRequired,
+  isSummaryCollapsable: PropTypes.bool,
 };
 
 const Summary = ({

--- a/components/Summary/Summary.module.scss
+++ b/components/Summary/Summary.module.scss
@@ -1,0 +1,14 @@
+.sectionTitle {
+  display: flex;
+  align-items: center;
+  a {
+    margin-left: 1rem;
+  }
+}
+
+.toggleAll {
+  text-decoration: underline;
+  font-weight: bold;
+  display: block;
+  text-align: right;
+}

--- a/components/Summary/Summary.spec.jsx
+++ b/components/Summary/Summary.spec.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import Summary from './Summary';
 
@@ -75,5 +75,50 @@ describe('Summary component', () => {
   it('should render properly', () => {
     const { asFragment } = render(<Summary {...props} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  describe('isSummaryCollapsable', () => {
+    const localProps = {
+      formData: {
+        foo: '123',
+      },
+      formPath: '/form/foo/',
+      formSteps: [
+        {
+          id: 'first-step',
+          title: 'First Step',
+          components: [
+            {
+              component: 'TextInput',
+              label: 'I am foo component',
+              name: 'foo',
+            },
+          ],
+        },
+      ],
+    };
+
+    it('should render properly - with isSummaryCollapsable', () => {
+      const { asFragment, getByText, queryByText } = render(
+        <Summary {...localProps} isSummaryCollapsable />
+      );
+      expect(asFragment()).toMatchSnapshot();
+      expect(getByText('Collapse all')).toBeInTheDocument();
+      expect(queryByText('I am foo component')).toBeInTheDocument();
+
+      fireEvent.click(getByText('Collapse view'));
+      expect(queryByText('Collapse all')).not.toBeInTheDocument();
+      expect(queryByText('Expand all')).toBeInTheDocument();
+
+      fireEvent.click(getByText('Expand all'));
+      expect(queryByText('Collapse all')).toBeInTheDocument();
+      expect(queryByText('Expand all')).not.toBeInTheDocument();
+      expect(queryByText('I am foo component')).toBeInTheDocument();
+    });
+
+    it('should render properly - with No isSummaryCollapsable', () => {
+      const { asFragment } = render(<Summary {...localProps} />);
+      expect(asFragment()).toMatchSnapshot();
+    });
   });
 });

--- a/components/Summary/__snapshots__/Summary.spec.jsx.snap
+++ b/components/Summary/__snapshots__/Summary.spec.jsx.snap
@@ -1,5 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Summary component isSummaryCollapsable should render properly - with No isSummaryCollapsable 1`] = `
+<DocumentFragment>
+  <div
+    class="govuk-!-margin-bottom-7"
+  >
+    <div
+      class="lbh-table-header"
+    >
+      <div
+        class="sectionTitle"
+      >
+        <h3
+          class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+        >
+          FIRST STEP
+        </h3>
+      </div>
+    </div>
+    <hr
+      class="govuk-divider"
+    />
+    <dl
+      class="govuk-summary-list"
+    >
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          I am foo component
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          123
+        </dd>
+      </div>
+    </dl>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Summary component isSummaryCollapsable should render properly - with isSummaryCollapsable 1`] = `
+<DocumentFragment>
+  <span
+    class="govuk-link toggleAll"
+    role="button"
+  >
+    Collapse all
+  </span>
+  <div
+    class="govuk-!-margin-bottom-7"
+  >
+    <div
+      class="lbh-table-header"
+    >
+      <div
+        class="sectionTitle"
+      >
+        <h3
+          class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+        >
+          FIRST STEP
+        </h3>
+      </div>
+      <span
+        class="govuk-link govuk-link--underline"
+        role="button"
+      >
+        Collapse view
+      </span>
+    </div>
+    <hr
+      class="govuk-divider"
+    />
+    <dl
+      class="govuk-summary-list"
+    >
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          I am foo component
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          123
+        </dd>
+      </div>
+    </dl>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Summary component should render properly 1`] = `
 <DocumentFragment>
   <div
@@ -8,11 +106,15 @@ exports[`Summary component should render properly 1`] = `
     <div
       class="lbh-table-header"
     >
-      <h3
-        class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+      <div
+        class="sectionTitle"
       >
-        FIRST STEP
-      </h3>
+        <h3
+          class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+        >
+          FIRST STEP
+        </h3>
+      </div>
     </div>
     <hr
       class="govuk-divider"
@@ -56,11 +158,15 @@ exports[`Summary component should render properly 1`] = `
     <div
       class="lbh-table-header"
     >
-      <h3
-        class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+      <div
+        class="sectionTitle"
       >
-        SECOND STEP
-      </h3>
+        <h3
+          class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+        >
+          SECOND STEP
+        </h3>
+      </div>
     </div>
     <hr
       class="govuk-divider"
@@ -90,11 +196,15 @@ exports[`Summary component should render properly 1`] = `
     <div
       class="lbh-table-header"
     >
-      <h3
-        class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+      <div
+        class="sectionTitle"
       >
-        OBJECT STEP
-      </h3>
+        <h3
+          class="govuk-heading-m govuk-custom-text-color govuk-!-margin-bottom-0"
+        >
+          OBJECT STEP
+        </h3>
+      </div>
     </div>
     <hr
       class="govuk-divider"

--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -49,7 +49,7 @@ describe('Test Form', () => {
     cy.contains('MULTI STEP - 2').should('be.visible');
     cy.contains('foo second').should('be.visible');
     cy.contains('Add Another Multi Step').should('be.visible');
-    cy.contains('Edit details').should('be.visible');
+    cy.contains('Edit').should('be.visible');
 
     cy.contains('Submit').click();
     cy.wait('@apiCheck').then((interception) => {

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -93,6 +93,10 @@ $screen-sm-min: 576px;
   color: $govuk-link-hover-colour;
 }
 
+.govuk-link--underline {
+  text-decoration: underline;
+}
+
 .width-override-10 {
   max-width: 23ex;
 }

--- a/utils/objects.js
+++ b/utils/objects.js
@@ -55,3 +55,6 @@ export const sanitiseObject = (object) =>
         (acc, [key, value]) => sanitise(acc, value, key),
         {}
       );
+
+export const setValues = (object, value) =>
+  Object.keys(object).reduce((acc, key) => ({ ...acc, [key]: value }), {});

--- a/utils/objects.spec.js
+++ b/utils/objects.spec.js
@@ -1,4 +1,4 @@
-import { deepmerge, sanitiseObject } from './objects';
+import { deepmerge, sanitiseObject, setValues } from './objects';
 
 describe('objects util', () => {
   describe('deepmerge', () => {
@@ -60,6 +60,15 @@ describe('objects util', () => {
         phone_number: [{ phoneNumber: '123123', phoneType: '' }],
         arr: ['foo', 123],
         cippa: { yo: { asd: { asd: 123 } } },
+      });
+    });
+  });
+
+  describe('setValues', () => {
+    it('should work properly', () => {
+      expect(setValues({ foo: 'bar', foobar: true }, false)).toEqual({
+        foo: false,
+        foobar: false,
       });
     });
   });

--- a/utils/summary.jsx
+++ b/utils/summary.jsx
@@ -91,3 +91,14 @@ export const formatData = (componentProps, formData) => {
       : formData[name],
   };
 };
+
+export const getSectionObject = (formSteps, formData, value = false) =>
+  formSteps.reduce((acc, { id, isMulti }) => {
+    const stepIds = isMulti
+      ? formData[id]?.reduce(
+          (acc, _, key) => ({ ...acc, [`${id}/${key + 1}`]: false }),
+          {}
+        )
+      : { [id]: value };
+    return { ...acc, ...stepIds };
+  }, {});

--- a/utils/summary.spec.jsx
+++ b/utils/summary.spec.jsx
@@ -1,4 +1,4 @@
-import { formatData } from './summary';
+import { formatData, getSectionObject } from './summary';
 
 describe('Summary utils', () => {
   describe('formatData', () => {
@@ -114,6 +114,19 @@ describe('Summary utils', () => {
         text: ['i', 'm', 'multi', 'text'],
       };
       expect(formatData(componentProps, formData)).toMatchSnapshot();
+    });
+  });
+
+  describe('getSectionObject', () => {
+    it('should work properly', () => {
+      const formSteps = [{ id: 'foo' }, { id: 'bar', isMulti: true }];
+      const formData = { foo: '', bar: [1, 2, 3] };
+      expect(getSectionObject(formSteps, formData)).toEqual({
+        foo: false,
+        'bar/1': false,
+        'bar/2': false,
+        'bar/3': false,
+      });
     });
   });
 });


### PR DESCRIPTION
**What**  
Added collapse/expand functionality to the summary component

Behaviour:
```
no collapsed section -> collapse all
1 or more section collapsed -> expand all
```

<img width="804" alt="Screenshot 2021-02-17 at 19 22 14" src="https://user-images.githubusercontent.com/435399/108261331-ca05a280-7163-11eb-9fec-2a70d9a2551b.png">
<img width="811" alt="Screenshot 2021-02-17 at 19 22 19" src="https://user-images.githubusercontent.com/435399/108261333-cb36cf80-7163-11eb-91f8-964e6222bd14.png">
<img width="804" alt="Screenshot 2021-02-17 at 19 22 27" src="https://user-images.githubusercontent.com/435399/108261334-cbcf6600-7163-11eb-94cc-0981db56db7e.png">


`FormWizard` supports `isSummaryCollapsable` default `true` for forms with more than 1 step.

**How to test it**
- Check the `/form/test`
