### PR TITLE
added search for worker email to case search

### DIFF
--- a/components/Search/Search.jsx
+++ b/components/Search/Search.jsx
@@ -32,11 +32,14 @@ const Search = ({ type }) => {
         ? {
             SearchForm: SearchCasesForm,
             SearchResults: CasesTable,
-            searchFunction: ({ my_notes_only, ...formData }, ...args) =>
+            searchFunction: (
+              { my_notes_only, worker_email, ...formData },
+              ...args
+            ) =>
               getCases(
                 {
                   ...formData,
-                  worker_email: my_notes_only ? user.email : '',
+                  worker_email: my_notes_only ? user.email : worker_email,
                 },
                 ...args
               ),

--- a/components/Search/Search.spec.jsx
+++ b/components/Search/Search.spec.jsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 
 import { UserContext } from 'components/UserContext/UserContext';
 import { getResidents } from 'utils/api/residents';
+import { getCases } from 'utils/api/cases';
 
 import Search from './Search';
 
@@ -17,6 +18,10 @@ jest.mock('next/router', () => ({
 
 jest.mock('utils/api/residents', () => ({
   getResidents: jest.fn(),
+}));
+
+jest.mock('utils/api/cases', () => ({
+  getCases: jest.fn(),
 }));
 
 describe(`Search`, () => {
@@ -125,5 +130,26 @@ describe(`Search`, () => {
     const errorLabel = await findByText('Oops an error occurred');
     expect(errorLabel).toBeInTheDocument();
     // expect(queryByText('Add New Person')).toBeInTheDocument();
+  });
+
+  it('should search Cases for user email if "Only include records I have created" is selected', () => {
+    getCases.mockImplementation(() => ({}));
+    mockedUseRouter.query = {
+      worker_email: 'worker@email.com',
+      my_notes_only: true,
+    };
+    render(
+      <UserContext.Provider
+        value={{
+          user: { email: 'user@email.com' },
+        }}
+      >
+        <Search {...props} type="records" />
+      </UserContext.Provider>
+    );
+    expect(getCases).toHaveBeenCalledWith(
+      { worker_email: 'user@email.com' },
+      true
+    );
   });
 });

--- a/components/Search/Search.spec.jsx
+++ b/components/Search/Search.spec.jsx
@@ -21,7 +21,7 @@ jest.mock('utils/api/residents', () => ({
 }));
 
 jest.mock('utils/api/cases', () => ({
-  getCases: jest.fn(),
+  useCases: jest.fn(),
 }));
 
 describe(`Search`, () => {

--- a/components/Search/forms/SearchCasesForm.jsx
+++ b/components/Search/forms/SearchCasesForm.jsx
@@ -3,7 +3,13 @@ import { useForm } from 'react-hook-form';
 import isPast from 'date-fns/isPast';
 
 import { convertFormat } from 'utils/date';
-import { TextInput, Checkbox, DateInput, Select } from 'components/Form';
+import {
+  TextInput,
+  EmailInput,
+  Checkbox,
+  DateInput,
+  Select,
+} from 'components/Form';
 import Button from 'components/Button/Button';
 import FORM_NAMES from 'data/formNames';
 
@@ -99,13 +105,21 @@ const SearchCasesForm = ({ onFormSubmit, defaultValues }) => {
         </div>
       </div>
       <div className="govuk-grid-row">
-        <div className="govuk-grid-column-full">
+        <div className="govuk-grid-column-one-half">
           <Select
             name="form_name"
             label="Filter by form type:"
             labelSize="s"
             register={register}
             options={FORM_NAMES}
+          />
+        </div>
+        <div className="govuk-grid-column-one-half">
+          <EmailInput
+            name="worker_email"
+            label="Worker email:"
+            labelSize="s"
+            register={register}
           />
         </div>
       </div>

--- a/components/Search/forms/SearchCasesForm.spec.jsx
+++ b/components/Search/forms/SearchCasesForm.spec.jsx
@@ -38,6 +38,7 @@ describe(`SearchCasesForm`, () => {
       my_notes_only: false,
       end_date: null,
       start_date: null,
+      worker_email: '',
     });
   });
 
@@ -60,6 +61,7 @@ describe(`SearchCasesForm`, () => {
       my_notes_only: true,
       end_date: null,
       start_date: null,
+      worker_email: '',
     });
   });
 
@@ -78,6 +80,7 @@ describe(`SearchCasesForm`, () => {
       my_notes_only: false,
       end_date: null,
       start_date: null,
+      worker_email: '',
     });
   });
 });


### PR DESCRIPTION
**What**  
<img width="988" alt="Screenshot 2021-02-18 at 12 23 33" src="https://user-images.githubusercontent.com/435399/108356545-8d31be00-71ec-11eb-94d3-3d606eeaa1dd.png">

**Note**
if `Only include records I've created` is selected this has the precedence over `worker_email`

<img width="489" alt="Screenshot 2021-02-18 at 12 28 38" src="https://user-images.githubusercontent.com/435399/108357072-40021c00-71ed-11eb-95c0-bba811265e44.png">
