### PR TITLE
fixed case notes post

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",
     "lint-staged": ">=10",
+    "mockdate": "^3.0.2",
     "prettier": "^2.2.1",
     "prop-types": "^15.7.2",
     "react-is": "^17.0.1",

--- a/pages/people/[id]/case-notes-recording/[[...stepId]].jsx
+++ b/pages/people/[id]/case-notes-recording/[[...stepId]].jsx
@@ -17,16 +17,13 @@ const CaseNotesRecording = () => {
   const onFormSubmit = useCallback(
     (person) => async (formData) => {
       const ref = await addCase({
-        mosaicId: person.mosaicId,
-        firstName: person.firstName,
-        lastName: person.lastName,
-        ageContext: person.ageContext,
-        workerEmail: user.email,
-        caseFormData: JSON.stringify({
-          form_name_overall:
-            person.ageContext === 'A' ? 'ASC_case_note' : 'CFS_case_note',
-          ...formData,
-        }),
+        mosaic_id: person.mosaicId,
+        first_name: person.firstName,
+        last_name: person.lastName,
+        worker_email: user.email,
+        form_name_overall:
+          person.ageContext === 'A' ? 'ASC_case_note' : 'CFS_case_note',
+        ...formData,
       });
       return ref;
     },

--- a/utils/server/cases.js
+++ b/utils/server/cases.js
@@ -35,8 +35,17 @@ export const getCaseByResident = async (mosaic_id, case_id, params) => {
 };
 
 export const addCase = async (formData) => {
-  const { data } = await axios.post(`${ENDPOINT_API}/cases`, formData, {
-    headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
-  });
+  const { data } = await axios.post(
+    `${ENDPOINT_API}/cases`,
+    {
+      caseFormData: JSON.stringify({
+        timestamp: new Date(),
+        ...formData,
+      }),
+    },
+    {
+      headers: { 'Content-Type': 'application/json', 'x-api-key': AWS_KEY },
+    }
+  );
   return { ref: data?.['_id'] };
 };

--- a/utils/server/cases.spec.js
+++ b/utils/server/cases.spec.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import MockDate from 'mockdate';
 
 import * as casesAPI from './cases';
 
@@ -46,15 +47,19 @@ describe('cases APIs', () => {
   describe('addCase', () => {
     it('should work properly', async () => {
       axios.post.mockResolvedValue({ data: { _id: 'foobar' } });
+      MockDate.set('2000-11-22');
       const data = await casesAPI.addCase({ foo: 'bar' });
       expect(axios.post).toHaveBeenCalled();
       expect(axios.post.mock.calls[0][0]).toEqual(`${ENDPOINT_API}/cases`);
-      expect(axios.post.mock.calls[0][1]).toEqual({ foo: 'bar' });
+      expect(axios.post.mock.calls[0][1]).toEqual({
+        caseFormData: '{"timestamp":"2000-11-22T00:00:00.000Z","foo":"bar"}',
+      });
       expect(axios.post.mock.calls[0][2].headers).toEqual({
         'Content-Type': 'application/json',
         'x-api-key': AWS_KEY,
       });
       expect(data).toEqual({ ref: 'foobar' });
+      MockDate.reset();
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9839,6 +9839,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"


### PR DESCRIPTION
**What**  
Fixed `POST /cases`

We are passing all the meaningful information inside the `caseFormData`.

```
{
  caseFormData: `{"timestamp":"2021-02-19T16:02:27.325Z","worker_email":"asd@hackney.gov.uk","context_flag":"A","form_name":"Manager's Decision","mosaic_id":"234","first_name":"John","last_name":"Doe","date_of_event":"2000-10-01"}`
}
```

Added `mockdate` module for testing dates.

**How to test it**
- go to `people/:id/case-notes-recording`
- add a case note
- check that has been populated correctly