### PR TITLE
fix address lookup validation

### DIFF
--- a/components/Form/AddressLookup/AddressLookup.jsx
+++ b/components/Form/AddressLookup/AddressLookup.jsx
@@ -9,6 +9,15 @@ import { Select, TextInput } from 'components/Form';
 import Button from 'components/Button/Button';
 import { lookupPostcode } from 'utils/api/postcodeAPI';
 
+export const defaultValidation = ({ required = false } = {}) => ({
+  address: (value) =>
+    !required || value?.address?.length > 0 || 'You must enter an address',
+  postcode: (value) =>
+    (!required && (value?.postcode === '' || !value?.postcode)) ||
+    (value?.postcode && isPostcodeValid(value?.postcode)) ||
+    'You must enter a valid postcode',
+});
+
 const AddressBox = ({ name, disabled, value, onChange }) => {
   const [address, setAddress] = useState(value || {});
   const setNewAddress = useCallback(
@@ -164,14 +173,7 @@ const AddressLookup = ({
         rules={{
           ...rules,
           validate: {
-            address: (value) =>
-              !rules?.required ||
-              value?.address.length > 0 ||
-              'You must enter an address',
-            postcode: (value) =>
-              (!rules?.required && value?.postcode === '') ||
-              (value?.postcode && isPostcodeValid(value.postcode)) ||
-              'You must enter a valid postcode',
+            ...defaultValidation(rules),
             ...rules?.validate,
           },
         }}

--- a/components/Form/AddressLookup/AddressLookup.spec.tsx
+++ b/components/Form/AddressLookup/AddressLookup.spec.tsx
@@ -1,0 +1,35 @@
+import { defaultValidation } from './AddressLookup';
+
+describe('AddressLookup', () => {
+  describe('defaultValidation', () => {
+    it('should work properly - if not required', () => {
+      const validate = defaultValidation();
+      expect(validate.address()).toBe(true);
+      expect(validate.address({ address: '' })).toBe(true);
+      expect(validate.address({ address: 'foo' })).toBe(true);
+      expect(validate.postcode()).toBe(true);
+      expect(validate.postcode({ postcode: '' })).toBe(true);
+      expect(validate.postcode({ postcode: 'foo' })).toBe(
+        'You must enter a valid postcode'
+      );
+      expect(validate.postcode({ postcode: 'e83as' })).toBe(true);
+    });
+
+    it('should work properly - if required', () => {
+      const validate = defaultValidation({ required: true });
+      expect(validate.address()).toBe('You must enter an address');
+      expect(validate.address({ address: '' })).toBe(
+        'You must enter an address'
+      );
+      expect(validate.address({ address: 'foo' })).toBe(true);
+      expect(validate.postcode()).toBe('You must enter a valid postcode');
+      expect(validate.postcode({ postcode: '' })).toBe(
+        'You must enter a valid postcode'
+      );
+      expect(validate.postcode({ postcode: 'foo' })).toBe(
+        'You must enter a valid postcode'
+      );
+      expect(validate.postcode({ postcode: 'e83as' })).toBe(true);
+    });
+  });
+});

--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -58,6 +58,7 @@ describe('Test Form', () => {
         show_next_step: true,
         show_object_step: false,
         show_multi_select_step: false,
+        show_address_step: false,
         conditional_text: 'conditional name',
         'last-step': [{ title_3: 'foo first' }, { title_3: 'foo second' }],
         title_2: 'conditional step title',

--- a/data/forms/test.jsx
+++ b/data/forms/test.jsx
@@ -59,20 +59,22 @@ export default {
         {
           component: 'Checkbox',
           name: 'show_next_step',
-          width: '30',
           label: 'Show next step',
         },
         {
           component: 'Checkbox',
           name: 'show_multi_select_step',
-          width: '30',
           label: 'Show multi-select step',
         },
         {
           component: 'Checkbox',
           name: 'show_object_step',
-          width: '30',
           label: 'Show object step',
+        },
+        {
+          component: 'Checkbox',
+          name: 'show_address_step',
+          label: 'Show Address Lookup step',
         },
       ],
     },
@@ -123,6 +125,18 @@ export default {
               label: 'Phone type',
             },
           ],
+        },
+      ],
+    },
+    {
+      id: 'address-step',
+      title: 'Address Lookup Step',
+      conditionalRender: ({ show_address_step }) => show_address_step === true,
+      components: [
+        {
+          component: 'AddressLookup',
+          name: 'address',
+          label: 'Address',
         },
       ],
     },


### PR DESCRIPTION
**What**
- fixed validation if not required
  At the moment it's asking for a valid postcode even if not required
- added address lookup to the test form

**How to test it**
- added address lookup in test form 
