### PR TITLE
only allow to access add and removed url if part of the correct user group

### DIFF
--- a/pages/people/[id]/allocations/[allocationId]/remove.tsx
+++ b/pages/people/[id]/allocations/[allocationId]/remove.tsx
@@ -4,9 +4,20 @@ import { useRouter } from 'next/router';
 import DeallocateWorkers from 'components/AllocatedWorkers/DeallocateWorker/DeallocateWorker';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import PersonView from 'components/PersonView/PersonView';
+import { useAuth } from 'components/UserContext/UserContext';
+import { isBrowser } from 'utils/ssr';
 
-const RemovedAllocationPage = () => {
-  const { query } = useRouter();
+import type { Resident } from 'types';
+
+const RemovedAllocationPage = (): React.ReactElement => {
+  const { query, replace } = useRouter();
+  const personId = query.id as string;
+  const allocationId = query.id as string;
+  const { user } = useAuth();
+  if (isBrowser() && !user?.hasAllocationsPermissions) {
+    replace(`/people/${personId}`);
+    return <></>;
+  }
   return (
     <>
       <NextSeo title={`#${query.id} Cases`} noindex />
@@ -14,12 +25,12 @@ const RemovedAllocationPage = () => {
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
         Deallocate worker from
       </h1>
-      <PersonView personId={query.id} expandView={true} nameSize="m">
-        {(person) => (
+      <PersonView personId={personId} expandView={true}>
+        {(person: Resident) => (
           <div className="govuk-!-margin-top-7">
             <DeallocateWorkers
               personId={person.mosaicId}
-              allocationId={query.allocationId}
+              allocationId={allocationId}
             />
           </div>
         )}

--- a/pages/people/[id]/allocations/add.tsx
+++ b/pages/people/[id]/allocations/add.tsx
@@ -4,9 +4,19 @@ import { useRouter } from 'next/router';
 import AddAllocatedWorker from 'components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import PersonView from 'components/PersonView/PersonView';
+import { useAuth } from 'components/UserContext/UserContext';
+import { isBrowser } from 'utils/ssr';
 
-const AddNewAllocationPage = () => {
-  const { query } = useRouter();
+import type { Resident } from 'types';
+
+const AddNewAllocationPage = (): React.ReactElement => {
+  const { query, replace } = useRouter();
+  const personId = query.id as string;
+  const { user } = useAuth();
+  if (isBrowser() && !user?.hasAllocationsPermissions) {
+    replace(`/people/${personId}`);
+    return <></>;
+  }
   return (
     <>
       <NextSeo title={`#${query.id} Cases`} noindex />
@@ -14,8 +24,8 @@ const AddNewAllocationPage = () => {
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
         Allocate worker to
       </h1>
-      <PersonView personId={query.id} expandView={true} nameSize="m">
-        {(person) => (
+      <PersonView personId={personId} expandView={true}>
+        {(person: Resident) => (
           <div className="govuk-!-margin-top-7">
             <AddAllocatedWorker
               personId={person.mosaicId}


### PR DESCRIPTION
**What**  
A user that is not part of the allocators group won't be able to access `/person/:id/allocations/add` and `/person/:id/allocations/:allocationId/remove`

**How to test it**
- try to navigate to the addresses listed above as user without `hasAllocationsPermissions` and see that you are going to be redirected to the person page
- try to do the same but with a user with `hasAllocationsPermissions` and it should work as before