### PR TITLE
removed next/seo, used next/head instead

### DIFF
--- a/components/FormWizard/FormWizard.jsx
+++ b/components/FormWizard/FormWizard.jsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import Router, { useRouter } from 'next/router';
-import { NextSeo } from 'next-seo';
 import { useBeforeunload } from 'react-beforeunload';
 
+import Seo from 'components/Layout/Seo/Seo';
 import DynamicStep from 'components/FormWizard/DynamicStep';
 import Breadcrumbs from 'components/Breadcrumbs/Breadcrumbs';
 import { createSteps, getNextStepPath, haveStepsChanged } from 'utils/steps';
@@ -55,7 +55,7 @@ const FormWizard = ({
   const StepComponent = step.component ? step.component : DynamicStep;
   return (
     <div className="govuk-width-container">
-      <NextSeo title={`${step.title} - ${title}`} noindex={true} />
+      <Seo title={`${step.title} - ${title}`} />
       {!hideBackButton && currentStepIndex !== 0 && step.id !== 'confirmation' && (
         <a className="govuk-back-link" href="#" onClick={() => Router.back()}>
           Back

--- a/components/Layout/Seo/Seo.spec.tsx
+++ b/components/Layout/Seo/Seo.spec.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+
+import Seo from './Seo';
+
+jest.mock('next/head', () => {
+  const mockedHead = ({ children }: { children: React.ReactChild }) => (
+    <>{children}</>
+  );
+  return mockedHead;
+});
+
+describe('Seo component', () => {
+  it('should work properly', () => {
+    const { asFragment } = render(<Seo title="foo" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/Layout/Seo/Seo.tsx
+++ b/components/Layout/Seo/Seo.tsx
@@ -1,0 +1,13 @@
+import Head from 'next/head';
+
+interface Props {
+  title: string;
+}
+
+const Seo = ({ title }: Props): React.ReactElement => (
+  <Head>
+    <title>{title} - Interim Social Care Admin - Hackney Council</title>
+  </Head>
+);
+
+export default Seo;

--- a/components/Layout/Seo/__snapshots__/Seo.spec.tsx.snap
+++ b/components/Layout/Seo/__snapshots__/Seo.spec.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Seo component should work properly 1`] = `
+<DocumentFragment>
+  <title>
+    foo - Interim Social Care Admin - Hackney Council
+  </title>
+</DocumentFragment>
+`;

--- a/components/Layout/index.jsx
+++ b/components/Layout/index.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 
+import Seo from './Seo/Seo';
 import Footer from './Footer/Footer';
 import Header from './Header/Header';
 import SkipLink from './SkipLink/SkipLink';
@@ -9,6 +10,7 @@ const Layout = ({ children }) => {
   const feedbackLink = process.env.NEXT_PUBLIC_FEEDBACK_LINK || '';
   return (
     <>
+      <Seo title="Interim Social Care Admin - Hackney Council" />
       <SkipLink />
       <Header serviceName="Interim Social Care" />
       <div className="govuk-width-container app-width-container">

--- a/next-seo.config.js
+++ b/next-seo.config.js
@@ -1,3 +1,0 @@
-export default {
-  titleTemplate: '%s - Interim Social Care Admin - Hackney Council',
-};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "jsonwebtoken": "^8.5.1",
     "lodash.get": "^4.4.2",
     "next": "10.0.5",
-    "next-seo": "^4.17.0",
     "react": "17.0.1",
     "react-beforeunload": "^2.4.0",
     "react-dom": "17.0.1",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,10 +1,8 @@
 import App from 'next/app';
-import { DefaultSeo } from 'next-seo';
 import axios from 'axios';
 import { SWRConfig } from 'swr';
 
 import Layout from 'components/Layout';
-import SEO from '../next-seo.config';
 import GoogleAnalytics from 'components/GoogleAnalytics/GoogleAnalytics';
 import { AuthProvider } from 'components/UserContext/UserContext';
 import { isAuthorised, shouldRedirect } from 'utils/auth';
@@ -33,7 +31,6 @@ class MyApp extends App {
           <AuthProvider user={this.state.user}>
             <GoogleAnalytics>
               <Layout>
-                <DefaultSeo {...SEO} />
                 <Component {...pageProps} />
               </Layout>
             </GoogleAnalytics>

--- a/pages/access-denied.jsx
+++ b/pages/access-denied.jsx
@@ -1,8 +1,8 @@
-import { NextSeo } from 'next-seo';
+import Seo from 'components/Layout/Seo/Seo';
 
 const AccessDenied = () => (
   <>
-    <NextSeo title="Access Denied" noindex={true} />
+    <Seo title="Access Denied" />
     <h1>Access denied</h1>
     <p className="govuk-body">
       Sorry, but access to that page is for administrators only.

--- a/pages/cases/index.jsx
+++ b/pages/cases/index.jsx
@@ -1,10 +1,9 @@
-import { NextSeo } from 'next-seo';
-
+import Seo from 'components/Layout/Seo/Seo';
 import Search from 'components/Search/Search';
 
 const SearchCasesPage = () => (
   <div>
-    <NextSeo title="Find unlinked case notes" noindex />
+    <Seo title="Find unlinked case notes" />
     <Search type="records" />
   </div>
 );

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,10 +1,9 @@
-import { NextSeo } from 'next-seo';
-
+import Seo from 'components/Layout/Seo/Seo';
 import Search from 'components/Search/Search';
 
 const SearchResidentPage = () => (
   <div>
-    <NextSeo title="Search" noindex />
+    <Seo title="Search" />
     <Search type="people" />
   </div>
 );

--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
-import { NextSeo } from 'next-seo';
 
+import Seo from 'components/Layout/Seo/Seo';
 import { getProtocol } from 'utils/urls';
 
 const AdminLoginPage = ({ gssoUrl, returnUrl }) => (
   <>
-    <NextSeo title="Log In" noindex />
+    <Seo title="Log In" />
     <h1>Login</h1>
     <p className="govuk-body">Please log in with your Hackney email account.</p>
     <div>

--- a/pages/people/[id]/allocations/[allocationId]/index.jsx
+++ b/pages/people/[id]/allocations/[allocationId]/index.jsx
@@ -1,6 +1,6 @@
-import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 
+import Seo from 'components/Layout/Seo/Seo';
 import AllocationRecap from 'components/AllocatedWorkers/AllocationRecap/AllocationRecap';
 import BackButton from 'components/Layout/BackButton/BackButton';
 
@@ -10,7 +10,7 @@ const AllocationPage = () => {
   } = useRouter();
   return (
     <>
-      <NextSeo title={`#${id} Allocation`} noindex />
+      <Seo title={`#${id} Allocation`} />
       <BackButton />
       <AllocationRecap
         personId={id}

--- a/pages/people/[id]/allocations/[allocationId]/remove.tsx
+++ b/pages/people/[id]/allocations/[allocationId]/remove.tsx
@@ -1,6 +1,6 @@
-import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 
+import Seo from 'components/Layout/Seo/Seo';
 import DeallocateWorkers from 'components/AllocatedWorkers/DeallocateWorker/DeallocateWorker';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import PersonView from 'components/PersonView/PersonView';
@@ -20,7 +20,7 @@ const RemovedAllocationPage = (): React.ReactElement => {
   }
   return (
     <>
-      <NextSeo title={`#${query.id} Cases`} noindex />
+      <Seo title={`#${query.id} Cases`} />
       <BackButton />
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
         Deallocate worker from

--- a/pages/people/[id]/allocations/add.tsx
+++ b/pages/people/[id]/allocations/add.tsx
@@ -1,4 +1,4 @@
-import { NextSeo } from 'next-seo';
+import Seo from 'components/Layout/Seo/Seo';
 import { useRouter } from 'next/router';
 
 import AddAllocatedWorker from 'components/AllocatedWorkers/AddAllocatedWorker/AddAllocatedWorker';
@@ -19,7 +19,7 @@ const AddNewAllocationPage = (): React.ReactElement => {
   }
   return (
     <>
-      <NextSeo title={`#${query.id} Cases`} noindex />
+      <Seo title={`#${query.id} Cases`} />
       <BackButton />
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
         Allocate worker to

--- a/pages/people/[id]/case-notes-recording/[[...stepId]].tsx
+++ b/pages/people/[id]/case-notes-recording/[[...stepId]].tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/router';
-import { NextSeo } from 'next-seo';
 
+import Seo from 'components/Layout/Seo/Seo';
 import PersonView from 'components/PersonView/PersonView';
 import { useAuth } from 'components/UserContext/UserContext';
 import BackButton from 'components/Layout/BackButton/BackButton';
@@ -39,7 +39,7 @@ const CaseNotesRecording = (): React.ReactElement => {
   );
   return (
     <>
-      <NextSeo title="Case note" noindex />
+      <Seo title="Case note" />
       <>
         <BackButton />
         <h1 className="govuk-fieldset__legend--l gov-weight-lighter">

--- a/pages/people/[id]/index.jsx
+++ b/pages/people/[id]/index.jsx
@@ -1,6 +1,6 @@
-import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 
+import Seo from 'components/Layout/Seo/Seo';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import PersonView from 'components/PersonView/PersonView';
 import Cases from 'components/Cases/Cases';
@@ -10,7 +10,7 @@ const PersonPage = () => {
   const { query } = useRouter();
   return (
     <div>
-      <NextSeo title={`#${query.id} Cases`} noindex />
+      <Seo title={`#${query.id} Cases`} />
       <BackButton />
       <PersonView personId={query.id}>
         {(person) => (

--- a/pages/people/[id]/records/conversation-1/[[...stepId]].tsx
+++ b/pages/people/[id]/records/conversation-1/[[...stepId]].tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, ReactElement } from 'react';
 import { useRouter } from 'next/router';
-import { NextSeo } from 'next-seo';
 
+import Seo from 'components/Layout/Seo/Seo';
 import PersonView from 'components/PersonView/PersonView';
 import { useAuth } from 'components/UserContext/UserContext';
 import BackButton from 'components/Layout/BackButton/BackButton';
@@ -41,7 +41,7 @@ const CaseNotesRecording = (): ReactElement => {
   );
   return (
     <>
-      <NextSeo title="Case note" noindex />
+      <Seo title="Conversation 1 Form" />
       <>
         <BackButton />
         <h1 className="govuk-fieldset__legend--l gov-weight-lighter">

--- a/pages/people/[id]/records/index.jsx
+++ b/pages/people/[id]/records/index.jsx
@@ -1,6 +1,6 @@
-import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 
+import Seo from 'components/Layout/Seo/Seo';
 import AddForm from 'components/AddForm/AddForm';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import PersonView from 'components/PersonView/PersonView';
@@ -9,7 +9,7 @@ const AddNewRecordPage = () => {
   const { query } = useRouter();
   return (
     <>
-      <NextSeo title={`#${query.id} Cases`} noindex />
+      <Seo title={`#${query.id} Cases`} />
       <BackButton />
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
         Add a new record for

--- a/pages/workers/[id]/index.jsx
+++ b/pages/workers/[id]/index.jsx
@@ -1,6 +1,6 @@
-import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 
+import Seo from 'components/Layout/Seo/Seo';
 import AllocatedCases from 'components/AllocatedCases/AllocatedCases';
 import BackButton from 'components/Layout/BackButton/BackButton';
 
@@ -8,7 +8,7 @@ const Workers = () => {
   const { query } = useRouter();
   return (
     <div>
-      <NextSeo title={`#${query.id} Allocation Workers`} noindex />
+      <Seo title={`#${query.id} Allocation Workers`} />
       <BackButton />
       <AllocatedCases id={query.id} />
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10065,11 +10065,6 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-next-seo@^4.17.0:
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-4.17.0.tgz#fb3dbe0ed7414aa9d83872ef5d8510980a6dae7e"
-  integrity sha512-/hnb3oq7bhi8s7bup7+Lm6VzzgRucj+JrWtp+dJiYs/04H0N/NhmE9MpepixQ16fFj6G/39JLYxhzsO/QZG/Kw==
-
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
**What**  
- Removed third-party module `next/seo` in favour of the native `next/head` (https://nextjs.org/docs/api-reference/next/head)
- `next-seo` was roughtly 7kb gzip according to bundlephobia https://bundlephobia.com/result?p=next-seo@4.20.0
- `noidex` is already been covered by https://github.com/LBHackney-IT/lbh-social-care/blob/main/public/robots.txt

**How to test it**
Page titles should work as before
