### PR TITLE
hide caseFormTimestamp from cases

### DIFF
--- a/components/Cases/CasesTable.jsx
+++ b/components/Cases/CasesTable.jsx
@@ -10,11 +10,10 @@ const CasesEntry = ({
   officerEmail,
   dateOfEvent,
   caseFormData,
-  caseFormTimestamp,
 }) => (
   <tr className="govuk-table__row">
     <td className="govuk-table__cell govuk--timestamp">
-      {formatDate(dateOfEvent || caseFormTimestamp)}{' '}
+      {formatDate(dateOfEvent)}{' '}
     </td>
     <td className="govuk-table__cell">{formName}</td>
     <td className="govuk-table__cell">

--- a/components/Cases/__snapshots__/Cases.spec.jsx.snap
+++ b/components/Cases/__snapshots__/Cases.spec.jsx.snap
@@ -164,7 +164,7 @@ exports[`Cases component should render records properly 1`] = `
         <td
           class="govuk-table__cell govuk--timestamp"
         >
-          4 Dec 2020 
+           
         </td>
         <td
           class="govuk-table__cell"

--- a/components/Search/results/CasesTable.jsx
+++ b/components/Search/results/CasesTable.jsx
@@ -9,7 +9,6 @@ const CasesEntry = ({
   dateOfBirth,
   officerEmail,
   dateOfEvent,
-  caseFormTimestamp,
 }) => (
   <tr className="govuk-table__row">
     <td className="govuk-table__cell">
@@ -19,9 +18,7 @@ const CasesEntry = ({
       {isDateValid(dateOfBirth) && dateOfBirth}
     </td>
     <td className="govuk-table__cell">{officerEmail}</td>
-    <td className="govuk-table__cell">
-      {formatDate(dateOfEvent || caseFormTimestamp)}
-    </td>
+    <td className="govuk-table__cell">{formatDate(dateOfEvent)}</td>
     <td className="govuk-table__cell govuk-button--secondary'">
       {caseFormUrl && (
         <a


### PR DESCRIPTION
**What**  
At the moment the BE is returning cases sorted in 2 groups, the first one by `dateOfEvent` and if it's not present by `caseFormTimestamp`. This is leading to some confusion in the UI.

This should be rolledback once the BE is merging the two sorting.
