### PR TITLE
initialise phoneNumber type as main if not present

### DIFF
--- a/utils/server/residents.spec.ts
+++ b/utils/server/residents.spec.ts
@@ -104,12 +104,51 @@ describe('residents APIs', () => {
       expect(mockedAxios.post.mock.calls[0][0]).toEqual(
         `${ENDPOINT_API}/residents`
       );
-      expect(mockedAxios.post.mock.calls[0][1]).toEqual({ foo: 'bar' });
+      expect(mockedAxios.post.mock.calls[0][1]).toEqual({
+        foo: 'bar',
+        phoneNumbers: null,
+      });
       expect(mockedAxios.post.mock.calls[0][2]?.headers).toEqual({
         'Content-Type': 'application/json',
         'x-api-key': AWS_KEY,
       });
       expect(data).toEqual({ _id: 'foobar' });
+    });
+  });
+
+  const fixture = {
+    phoneNumbers: [
+      { number: '213213', type: '' },
+      { number: '12321', type: 'qwe' },
+      { number: '321321', type: '' },
+    ],
+    contextFlag: 'A',
+    firstName: 'asd',
+    lastName: 'asd',
+    gender: 'U',
+    dateOfBirth: '2000-12-12',
+    address: { address: 'qweqwe', postcode: 'e83as' },
+    nhsNumber: null,
+    createdBy: 'luca.lischetti@hackney.gov.uk',
+  };
+
+  describe('normalisePhoneInput', () => {
+    it('should work properly', () => {
+      expect(residentsAPI.normalisePhoneInput(fixture)).toEqual({
+        phoneNumbers: [
+          { number: '213213', type: 'main' },
+          { number: '12321', type: 'qwe' },
+          { number: '321321', type: 'main' },
+        ],
+        contextFlag: 'A',
+        firstName: 'asd',
+        lastName: 'asd',
+        gender: 'U',
+        dateOfBirth: '2000-12-12',
+        address: { address: 'qweqwe', postcode: 'e83as' },
+        nhsNumber: null,
+        createdBy: 'luca.lischetti@hackney.gov.uk',
+      });
     });
   });
 });

--- a/utils/server/residents.ts
+++ b/utils/server/residents.ts
@@ -55,11 +55,28 @@ export const getResident = async (
   return sanitiseResidentData(data.residents)?.[0];
 };
 
+export const normalisePhoneInput = (formData: {
+  phoneNumbers?: Record<string, string>[];
+  [key: string]: unknown;
+}): Record<string, unknown> => ({
+  ...formData,
+  phoneNumbers: formData.phoneNumbers
+    ? formData.phoneNumbers.map((phone) => ({
+        ...phone,
+        type: phone.type === '' ? 'main' : phone.type,
+      }))
+    : null,
+});
+
 export const addResident = async (
   formData: Record<string, unknown>
 ): Promise<ResidentAPI> => {
-  const { data } = await axios.post(`${ENDPOINT_API}/residents`, formData, {
-    headers: { ...headers, 'Content-Type': 'application/json' },
-  });
+  const { data } = await axios.post(
+    `${ENDPOINT_API}/residents`,
+    normalisePhoneInput(formData),
+    {
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    }
+  );
   return data;
 };


### PR DESCRIPTION
**What**  
If the user inserts a number but not the type the form is valid but the BE breaks.

This is a temporary quick fix as production is broken.


**How to test it**
- create a new person and as a phone number specify the number but not the type.