### PR TITLE
mocked getWarningNotes

### DIFF
--- a/pages/api/residents/[id]/warning-notes/index.ts
+++ b/pages/api/residents/[id]/warning-notes/index.ts
@@ -1,0 +1,52 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { getWarningNotes } from 'utils/server/warningNotes';
+import { isAuthorised } from 'utils/auth';
+
+import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
+
+const endpoint: NextApiHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+) => {
+  const user = isAuthorised(req);
+  if (!user) {
+    return res.status(StatusCodes.UNAUTHORIZED).end();
+  }
+  if (!user.isAuthorised) {
+    return res.status(StatusCodes.FORBIDDEN).end();
+  }
+  switch (req.method) {
+    case 'GET':
+      try {
+        const data = await getWarningNotes(
+          parseInt(req.query.id as string, 10)
+          // {
+          //   context_flag: user.permissionFlag,
+          // }
+        );
+        data
+          ? res.status(StatusCodes.OK).json(data)
+          : res
+              .status(StatusCodes.NOT_FOUND)
+              .json({ message: 'Resident Not Found' });
+      } catch (error) {
+        console.error('Resident get error:', error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND
+          ? res
+              .status(StatusCodes.NOT_FOUND)
+              .json({ message: 'Resident Not Found' })
+          : res
+              .status(StatusCodes.INTERNAL_SERVER_ERROR)
+              .json({ message: 'Unable to get the Resident' });
+      }
+      break;
+
+    default:
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: 'Invalid request method' });
+  }
+};
+
+export default endpoint;

--- a/types.ts
+++ b/types.ts
@@ -68,3 +68,14 @@ export interface User {
   hasUnrestrictedPermissions?: boolean;
   isAuthorised: boolean;
 }
+
+export interface WarningNote {
+  id: number;
+  type: string;
+  createdBy: string;
+  createdDate: Date;
+  reviewedBy?: string;
+  reviewedDate?: Date;
+  closedBy?: string;
+  closedDate?: Date;
+}

--- a/utils/server/warningNotes.ts
+++ b/utils/server/warningNotes.ts
@@ -1,0 +1,43 @@
+import { WarningNote } from 'types';
+
+const { MOCKED_WARNING_NOTES } = process.env;
+
+export const getWarningNotes = async (
+  personId: number
+): Promise<WarningNote[] | []> => {
+  const mockedWN = !MOCKED_WARNING_NOTES
+    ? []
+    : personId % 3 === 0
+    ? []
+    : personId % 3 === 1
+    ? [
+        {
+          id: 123,
+          type: 'Risk to Adults',
+          createdDate: new Date(2020, 12, 12),
+          createdBy: 'Foo',
+          reviewsDate: new Date(2020, 12, 13),
+          reviewsBy: 'Bar',
+        },
+      ]
+    : [
+        {
+          id: 123,
+          type: 'Risk to Adults',
+          createdDate: new Date(2020, 12, 12),
+          createdBy: 'Foo',
+          reviewsDate: new Date(2020, 12, 13),
+          reviewsBy: 'Bar',
+        },
+        {
+          id: 234,
+          type: 'Risk to Staff',
+          createdDate: new Date(2020, 12, 22),
+          createdBy: 'Foo',
+        },
+      ];
+
+  return await new Promise((resolve) =>
+    setTimeout(() => resolve(mockedWN), 1000)
+  );
+};


### PR DESCRIPTION
**What**  
Mocked BE for warning notes.

In order to enable this mock the following env variable is needed `MOCKED_WARNING_NOTES=true`.

The new endpoint is `/api/residents/:residentId/warning-notes`.

There are 3 possible returns, based on the rest of the operation (`personId` / 3):

- if the rest is `0` it returns `[]`
- if the rest is `1` it returns

```
[
  {
    "id": 123,
    "type": "Risk to Adults",
    "createdDate": "2021-01-12T00:00:00.000Z",
    "createdBy": "Foo",
    "reviewsDate": "2021-01-13T00:00:00.000Z",
    "reviewsBy": "Bar"
  }
]
```

- if the rest is `2` it returns:

```
[
  {
    "id": 123,
    "type": "Risk to Adults",
    "createdDate": "2021-01-12T00:00:00.000Z",
    "createdBy": "Foo",
    "reviewsDate": "2021-01-13T00:00:00.000Z",
    "reviewsBy": "Bar"
  },
  {
    "id": 234,
    "type": "Risk to Staff",
    "createdDate": "2021-01-22T00:00:00.000Z",
    "createdBy": "Foo"
  }
]
```