### PR TITLE
added show details component

### DIFF
--- a/components/ExpandDetails/ExpandDetails.module.scss
+++ b/components/ExpandDetails/ExpandDetails.module.scss
@@ -1,0 +1,26 @@
+@import 'node_modules/govuk-frontend/govuk/base';
+
+.summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: 0;
+  border-bottom: 2px solid $govuk-border-colour;
+  &:before {
+    display: none;
+  }
+  &:focus {
+    outline: none;
+  }
+  &:focus .trigger {
+    @include govuk-focused-text;
+  }
+}
+
+.trigger {
+  cursor: pointer;
+}
+
+.content {
+  padding: 2rem 0;
+}

--- a/components/ExpandDetails/ExpandDetails.spec.tsx
+++ b/components/ExpandDetails/ExpandDetails.spec.tsx
@@ -1,0 +1,25 @@
+import { render, fireEvent } from '@testing-library/react';
+
+import ExpandDetails from './ExpandDetails';
+
+describe(`ExpandDetails`, () => {
+  const props = {
+    label: 'Show intructions',
+    triggerLabel: 'guidance',
+    children: <p>I am the content!</p>,
+  };
+
+  it('should render properly', () => {
+    const { asFragment } = render(<ExpandDetails {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should change the trigger label on collapse', () => {
+    const { getByText, queryByText } = render(
+      <ExpandDetails isDefaultOpen {...props} />
+    );
+    expect(queryByText('Expand guidance')).not.toBeInTheDocument();
+    fireEvent.click(getByText('Collapse guidance'));
+    expect(queryByText('Expand guidance')).toBeInTheDocument();
+  });
+});

--- a/components/ExpandDetails/ExpandDetails.stories.tsx
+++ b/components/ExpandDetails/ExpandDetails.stories.tsx
@@ -1,0 +1,33 @@
+import { Story } from '@storybook/react';
+
+import ExpandDetails, { Props } from './ExpandDetails';
+
+export default {
+  title: 'ExpandDetails',
+  component: ExpandDetails,
+};
+
+const Template: Story<Props> = (args) => <ExpandDetails {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'Show intructions',
+  triggerLabel: 'guidance',
+  children: (
+    <div>
+      foo <strong>bar</strong>
+    </div>
+  ),
+};
+
+export const DefaultOpen = Template.bind({});
+DefaultOpen.args = {
+  label: 'Show intructions',
+  triggerLabel: 'guidance',
+  isDefaultOpen: true,
+  children: (
+    <div>
+      foo <strong>bar</strong>
+    </div>
+  ),
+};

--- a/components/ExpandDetails/ExpandDetails.tsx
+++ b/components/ExpandDetails/ExpandDetails.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import cx from 'classnames';
+
+import styles from './ExpandDetails.module.scss';
+
+export interface Props {
+  label: string;
+  triggerLabel?: string;
+  children: React.ReactChild;
+  isDefaultOpen?: boolean;
+}
+
+const ExpandDetails = ({
+  label,
+  triggerLabel,
+  children,
+  isDefaultOpen = false,
+}: Props): React.ReactElement => {
+  const [isOpen, setIsOpen] = useState<boolean>(isDefaultOpen);
+  return (
+    <details
+      className="govuk-details"
+      data-module="govuk-details"
+      open={isDefaultOpen}
+    >
+      <summary className={styles.summary} onClick={() => setIsOpen(!isOpen)}>
+        <h3>{label}</h3>
+        <span
+          className={cx('govuk-link', 'govuk-link--underline', styles.trigger)}
+        >
+          {isOpen ? 'Collapse' : 'Expand'} {triggerLabel}
+        </span>
+      </summary>
+      <div className={styles.content}>{children}</div>
+    </details>
+  );
+};
+
+export default ExpandDetails;

--- a/components/ExpandDetails/__snapshots__/ExpandDetails.spec.tsx.snap
+++ b/components/ExpandDetails/__snapshots__/ExpandDetails.spec.tsx.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExpandDetails should render properly 1`] = `
+<DocumentFragment>
+  <details
+    class="govuk-details"
+    data-module="govuk-details"
+  >
+    <summary
+      class="summary"
+    >
+      <h3>
+        Show intructions
+      </h3>
+      <span
+        class="govuk-link govuk-link--underline trigger"
+      >
+        Expand guidance
+      </span>
+    </summary>
+    <div
+      class="content"
+    >
+      <p>
+        I am the content!
+      </p>
+    </div>
+  </details>
+</DocumentFragment>
+`;


### PR DESCRIPTION
**What**  
Expand the html `details` element https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details 

<img width="395" alt="Screenshot 2021-03-09 at 13 51 05" src="https://user-images.githubusercontent.com/435399/110482827-5d8a1d80-80e9-11eb-83c3-308d517bad36.png">
<img width="382" alt="Screenshot 2021-03-09 at 13 51 10" src="https://user-images.githubusercontent.com/435399/110482828-5ebb4a80-80e9-11eb-8a0d-6b3692534f2e.png">

**How to test it**
- run storybook `yarn storybook`
- check the new component http://192.168.0.2:6006/?path=/story/expanddetails--default