### PR TITLE
removed versioning of the lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,7 @@ service: lbh-social-care
 provider:
   name: aws
   runtime: nodejs14.x
+  versionFunctions: false
   region: eu-west-2
   stage: ${opt:stage}
 


### PR DESCRIPTION
**What**  
We reached the maximum size of the lambda storage.

This change will prevent to create a new version each deploy.
