### PR TITLE
fixed get case endpoint

### DIFF
--- a/components/AllocatedWorkers/AllocationRecap/AllocationRecap.jsx
+++ b/components/AllocatedWorkers/AllocationRecap/AllocationRecap.jsx
@@ -4,17 +4,14 @@ import Link from 'next/link';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import Spinner from 'components/Spinner/Spinner';
 import { useResidentAllocation } from 'utils/api/allocatedWorkers';
-import { useCaseByResident } from 'utils/api/cases';
+import { useCase } from 'utils/api/cases';
 
 const AllocationRecap = ({ personId, allocationId, recordId }) => {
   const { data: allocation, error: allocationError } = useResidentAllocation(
     personId,
     allocationId
   );
-  const { data: record, error: recordError } = useCaseByResident(
-    personId,
-    recordId
-  );
+  const { data: record, error: recordError } = useCase(recordId);
   if (recordError || allocationError) {
     return <ErrorMessage />;
   }

--- a/components/AllocatedWorkers/AllocationRecap/AllocationRecap.spec.jsx
+++ b/components/AllocatedWorkers/AllocationRecap/AllocationRecap.spec.jsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import AllocationRecap from './AllocationRecap';
 
 import { useResidentAllocation } from 'utils/api/allocatedWorkers';
-import { useCaseByResident } from 'utils/api/cases';
+import { useCase } from 'utils/api/cases';
 
 jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
@@ -12,7 +12,7 @@ jest.mock('utils/api/allocatedWorkers', () => ({
 }));
 
 jest.mock('utils/api/cases', () => ({
-  useCaseByResident: jest.fn(),
+  useCase: jest.fn(),
 }));
 
 describe(`AllocationRecap`, () => {
@@ -23,7 +23,7 @@ describe(`AllocationRecap`, () => {
   };
 
   it('should render properly on deallocation', async () => {
-    useCaseByResident.mockImplementation(() => ({
+    useCase.mockImplementation(() => ({
       data: {
         caseFormData: {
           form_name_overall: 'API_Deallocation',
@@ -44,12 +44,12 @@ describe(`AllocationRecap`, () => {
     }));
     const { asFragment } = render(<AllocationRecap {...props} />);
     expect(useResidentAllocation).toHaveBeenCalledWith('p_123', 'a_123');
-    expect(useCaseByResident).toHaveBeenCalledWith('p_123', 'r_123');
+    expect(useCase).toHaveBeenCalledWith('r_123');
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('should render properly on allocation', async () => {
-    useCaseByResident.mockImplementation(() => ({
+    useCase.mockImplementation(() => ({
       data: {
         caseFormData: {
           form_name_overall: 'API_Allocation',
@@ -69,7 +69,7 @@ describe(`AllocationRecap`, () => {
     }));
     const { asFragment } = render(<AllocationRecap {...props} />);
     expect(useResidentAllocation).toHaveBeenCalledWith('p_123', 'a_123');
-    expect(useCaseByResident).toHaveBeenCalledWith('p_123', 'r_123');
+    expect(useCase).toHaveBeenCalledWith('r_123');
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/components/Cases/CaseRecap/CaseRecap.jsx
+++ b/components/Cases/CaseRecap/CaseRecap.jsx
@@ -3,14 +3,11 @@ import PropTypes from 'prop-types';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import Spinner from 'components/Spinner/Spinner';
 import Summary from 'components/Summary/Summary';
-import { useCaseByResident } from 'utils/api/cases';
+import { useCase } from 'utils/api/cases';
 import * as form from 'data/forms';
 
 const CaseRecap = ({ personId, recordId }) => {
-  const { data: record, error: recordError } = useCaseByResident(
-    personId,
-    recordId
-  );
+  const { data: record, error: recordError } = useCase(recordId);
 
   const recordData =
     record && record.caseFormData && record.caseFormData.form_name_overall;

--- a/components/Cases/CaseRecap/CaseRecap.spec.jsx
+++ b/components/Cases/CaseRecap/CaseRecap.spec.jsx
@@ -1,13 +1,13 @@
 import { act, render } from '@testing-library/react';
 
 import { UserContext } from 'components/UserContext/UserContext';
-import { useCaseByResident } from 'utils/api/cases';
+import { useCase } from 'utils/api/cases';
 import CaseRecap from './CaseRecap';
 
 jest.mock('components/Spinner/Spinner', () => () => 'MockedSpinner');
 
 jest.mock('utils/api/cases', () => ({
-  useCaseByResident: jest.fn(),
+  useCase: jest.fn(),
 }));
 
 describe(`CaseRecap`, () => {
@@ -16,7 +16,7 @@ describe(`CaseRecap`, () => {
     personId: '123',
   };
   it('should update the queryString on search and run a new search - with load more', async () => {
-    useCaseByResident.mockImplementation(() => ({
+    useCase.mockImplementation(() => ({
       data: {
         caseFormTimestamp: '2021-02-26T16:48:29.093Z',
         officerEmail: 'foo@bar.com',

--- a/lib/cases.ts
+++ b/lib/cases.ts
@@ -34,14 +34,17 @@ export const getCasesByResident = (
   params: Record<string, unknown>
 ): Promise<CaseData> => getCases({ mosaic_id, ...params });
 
-export const getCaseByResident = async (
-  mosaic_id: number,
+export const getCase = async (
   case_id: string,
   params: Record<string, unknown>
 ): Promise<Case | undefined> => {
-  // TODO: this should be covered by the BE
-  const data = await getCases({ mosaic_id, ...params, limit: 100 });
-  return data.cases?.find(({ recordId }) => recordId === case_id);
+  const { data } = await axios.get(`${ENDPOINT_API}/cases/${case_id}`, {
+    headers: headersWithKey,
+    params,
+  });
+  return (
+    data && { ...data, caseFormData: sanitiseCaseFormData(data.caseFormData) }
+  );
 };
 
 export const addCase = async (

--- a/pages/api/cases/[caseId].ts
+++ b/pages/api/cases/[caseId].ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes';
 
-import { getCaseByResident } from 'lib/cases';
+import { getCase } from 'lib/cases';
 import { isAuthorised } from 'utils/auth';
 
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from 'next';
@@ -16,18 +16,14 @@ const endpoint: NextApiHandler = async (
   if (!user.isAuthorised) {
     return res.status(StatusCodes.FORBIDDEN).end();
   }
-  const { id, caseId, ...params } = req.query;
+  const { caseId, ...params } = req.query;
   switch (req.method) {
     case 'GET':
       try {
-        const data = await getCaseByResident(
-          parseInt(id as string, 10),
-          caseId as string,
-          {
-            ...params,
-            context_flag: user.permissionFlag,
-          }
-        );
+        const data = await getCase(caseId as string, {
+          ...params,
+          context_flag: user.permissionFlag,
+        });
         data
           ? res.status(StatusCodes.OK).json(data)
           : res

--- a/pages/people/[id]/records/[recordId]/index.tsx
+++ b/pages/people/[id]/records/[recordId]/index.tsx
@@ -17,7 +17,9 @@ const CaseView = (): React.ReactElement => {
         Case note for
       </h1>
       <PersonView personId={Number(id as string)} expandView>
-        <CaseRecap personId={id as string} recordId={recordId as string} />
+        <div className="govuk-!-margin-top-7">
+          <CaseRecap personId={id as string} recordId={recordId as string} />
+        </div>
       </PersonView>
     </>
   );

--- a/utils/api/cases.spec.ts
+++ b/utils/api/cases.spec.ts
@@ -11,7 +11,7 @@ jest.mock('swr');
 const mockSWRInfinite = jest.fn();
 
 describe('cases APIs', () => {
-  describe('getCases', () => {
+  describe('useCases', () => {
     it('should work properly', async () => {
       jest
         .spyOn(SWR, 'useSWRInfinite')
@@ -25,7 +25,7 @@ describe('cases APIs', () => {
     });
   });
 
-  describe('getCasesByResident', () => {
+  describe('useCasesByResident', () => {
     it('should work properly', () => {
       jest
         .spyOn(SWR, 'useSWRInfinite')
@@ -36,6 +36,14 @@ describe('cases APIs', () => {
       expect(mockSWRInfinite).toHaveBeenCalledWith(
         '/api/residents/123/cases?bar=foobar'
       );
+    });
+  });
+
+  describe('useCase', () => {
+    it('should work properly', () => {
+      jest.spyOn(SWR, 'default');
+      casesAPI.useCase(123);
+      expect(SWR.default).toHaveBeenCalledWith('/api/cases/123');
     });
   });
 

--- a/utils/api/cases.spec.ts
+++ b/utils/api/cases.spec.ts
@@ -42,7 +42,7 @@ describe('cases APIs', () => {
   describe('useCase', () => {
     it('should work properly', () => {
       jest.spyOn(SWR, 'default');
-      casesAPI.useCase(123);
+      casesAPI.useCase('123');
       expect(SWR.default).toHaveBeenCalledWith('/api/cases/123');
     });
   });

--- a/utils/api/cases.ts
+++ b/utils/api/cases.ts
@@ -23,11 +23,9 @@ export const useCasesByResident = (
   // @ts-ignore
   useSWRInfinite(getInfiniteKey(`/api/residents/${id}/cases`, 'cases', params));
 
-export const useCaseByResident = (
-  id: number,
+export const useCase = (
   caseId: number
-): responseInterface<CaseData, ErrorAPI> =>
-  useSWR(`/api/residents/${id}/cases/${caseId}`);
+): responseInterface<CaseData, ErrorAPI> => useSWR(`/api/cases/${caseId}`);
 
 export const addCase = async (
   formData: Record<string, unknown>

--- a/utils/api/cases.ts
+++ b/utils/api/cases.ts
@@ -24,7 +24,7 @@ export const useCasesByResident = (
   useSWRInfinite(getInfiniteKey(`/api/residents/${id}/cases`, 'cases', params));
 
 export const useCase = (
-  caseId: number
+  caseId: string
 ): responseInterface<CaseData, ErrorAPI> => useSWR(`/api/cases/${caseId}`);
 
 export const addCase = async (


### PR DESCRIPTION
**What**
- used proper backend endpoint for getCase, removed terrible hack
- fixed layout
- fixed types for `caseId`
- added missing unit test

Refactored `getCase` endpoint:
`/api/residents/:residentId/cases/:caseId` to `/api/cases/:caseId` as we don't need the `residentId`

**How to test it**
- check that `http://dev.hackney.gov.uk:3000/people/234/records/602fb668890134f6e767161f` is working properly
- check that `http://dev.hackney.gov.uk:3000/api/cases/602fb668890134f6e767161f` is working properly
