### PR TITLE
fixed types for rules

### DIFF
--- a/components/Form/types.ts
+++ b/components/Form/types.ts
@@ -4,11 +4,13 @@ import { InputHTMLAttributes } from 'react';
 import { RegisterOptions, ValidateResult } from 'react-hook-form';
 import TextInput from './TextInput/TextInput';
 
+type EnhancedValidate = (
+  data: any,
+  formData: Record<string, any>
+) => ValidateResult | Promise<ValidateResult>;
+
 interface EnhancedRules extends Omit<RegisterOptions, 'validate'> {
-  validate?: (
-    data: any,
-    formData: Record<string, any>
-  ) => ValidateResult | Promise<ValidateResult>;
+  validate?: EnhancedValidate | Record<string, EnhancedValidate>;
 }
 
 type LabelSize = 's' | 'm' | 'l' | 'xl';

--- a/data/forms/warning-note.tsx
+++ b/data/forms/warning-note.tsx
@@ -132,7 +132,18 @@ const WARNING_TYPE: Array<FormComponentStep> = [
     component: 'DateInput',
     name: 'end_date',
     label: 'Review / end date',
-    rules: { required: true },
+    rules: {
+      required: true,
+      validate: {
+        beforeStartDate: (value, { start_date }) =>
+          new Date(value).getTime() >= new Date(start_date).getTime() ||
+          'The Review / end date cannot be earlier than the Start date',
+        notMoreThanOneYear: (value, { start_date }) =>
+          new Date(value).getTime() - new Date(start_date).getTime() <=
+            365 * 24 * 60 * 60 * 1000 ||
+          'The Review / end date cannot be more than 1 year from the Start date',
+      },
+    },
   },
 ];
 


### PR DESCRIPTION
**What**  
- Fixed types for `rules`, supporting both scenarios

```
{ 
  validate: // validation logic
}

```

and

```
{
  validate: {
    firstValidation: // validation logic
    secondValidation: // validation logic
  }
}
```

- Added validation for `end date`, checks that it's not more than 1 year apart and it's not in the past, compared to the start date.

<img width="699" alt="Screenshot 2021-03-15 at 09 29 03" src="https://user-images.githubusercontent.com/435399/111132814-13d28480-857a-11eb-91db-7145ddc3c8a5.png">


**How to test it**
- go to `/people/234/warning-notes/add`
- test start date / end date