### PR TITLE
fixed formatting of the TextArea in the Summary

### DIFF
--- a/components/Cases/CaseRecap/__snapshots__/CaseRecap.spec.jsx.snap
+++ b/components/Cases/CaseRecap/__snapshots__/CaseRecap.spec.jsx.snap
@@ -77,7 +77,9 @@ exports[`CaseRecap should update the queryString on search and run a new search 
         <dd
           class="govuk-summary-list__value"
         >
-          <pre>
+          <pre
+            class="formattedTextArea"
+          >
             Foo bar
           </pre>
         </dd>

--- a/components/Cases/CaseRecap/__snapshots__/CaseRecap.spec.jsx.snap
+++ b/components/Cases/CaseRecap/__snapshots__/CaseRecap.spec.jsx.snap
@@ -77,7 +77,9 @@ exports[`CaseRecap should update the queryString on search and run a new search 
         <dd
           class="govuk-summary-list__value"
         >
-          Foo bar
+          <pre>
+            Foo bar
+          </pre>
         </dd>
       </div>
     </dl>

--- a/components/Summary/Summary.module.scss
+++ b/components/Summary/Summary.module.scss
@@ -12,3 +12,7 @@
   display: block;
   text-align: right;
 }
+
+.formattedTextArea {
+  white-space: pre-line;
+}

--- a/components/Summary/Summary.stories.jsx
+++ b/components/Summary/Summary.stories.jsx
@@ -15,6 +15,7 @@ Default.args = {
     asd: '',
     qwe: 'yo',
     foobar: 'asd',
+    textarea: 'asd\nasd\nasd\n',
   },
   formPath: '/form/foo/',
   formSteps: [
@@ -35,6 +36,17 @@ Default.args = {
           component: 'TextInput',
           label: 'I am foobar component',
           name: 'foobar',
+        },
+      ],
+    },
+    {
+      id: 'third-step',
+      title: 'TextArea Step',
+      components: [
+        {
+          component: 'TextArea',
+          label: 'I am a long text',
+          name: 'textarea',
         },
       ],
     },

--- a/components/Summary/SummaryList.spec.tsx
+++ b/components/Summary/SummaryList.spec.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+
+import SummaryList from './SummaryList';
+
+describe('SummaryList component', () => {
+  const props = {
+    list: [
+      {
+        key: 'foo',
+        title: 'Foo',
+        value: 'f_o_o',
+      },
+      {
+        key: 'bar',
+        title: 'Bar',
+        href: 'https://bar',
+        value: <span>f_o_o</span>,
+      },
+      {
+        key: 'foobar',
+        title: 'FooBar',
+        type: 'TextArea',
+        value: 'asd\nasd\nasd\n',
+      },
+    ],
+  };
+
+  it('should render properly', () => {
+    const { asFragment } = render(<SummaryList {...props} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/Summary/SummaryList.tsx
+++ b/components/Summary/SummaryList.tsx
@@ -1,3 +1,5 @@
+import styles from './Summary.module.scss';
+
 interface SummaryElement {
   key: string;
   title: string;
@@ -17,7 +19,11 @@ const SummaryList = ({ list }: Props): React.ReactElement => (
         <div key={key} className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">{title}</dt>
           <dd className="govuk-summary-list__value">
-            {type === 'TextArea' ? <pre>{value}</pre> : value}
+            {type === 'TextArea' ? (
+              <pre className={styles.formattedTextArea}>{value}</pre>
+            ) : (
+              value
+            )}
           </dd>
           {href && (
             <dd className="govuk-summary-list__actions">

--- a/components/Summary/SummaryList.tsx
+++ b/components/Summary/SummaryList.tsx
@@ -1,12 +1,24 @@
-import PropTypes from 'prop-types';
+interface SummaryElement {
+  key: string;
+  title: string;
+  value: React.ReactNode;
+  type?: string;
+  href?: string;
+}
 
-const SummaryList = ({ list }) => (
+interface Props {
+  list: SummaryElement[];
+}
+
+const SummaryList = ({ list }: Props): React.ReactElement => (
   <dl className="govuk-summary-list">
     {list &&
-      list.map(({ key, title, value, href }) => (
+      list.map(({ key, title, value, href, type }) => (
         <div key={key} className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">{title}</dt>
-          <dd className="govuk-summary-list__value">{value}</dd>
+          <dd className="govuk-summary-list__value">
+            {type === 'TextArea' ? <pre>{value}</pre> : value}
+          </dd>
           {href && (
             <dd className="govuk-summary-list__actions">
               <a className="govuk-link" href="#">
@@ -19,16 +31,5 @@ const SummaryList = ({ list }) => (
       ))}
   </dl>
 );
-
-SummaryList.propTypes = {
-  list: PropTypes.arrayOf(
-    PropTypes.shape({
-      key: PropTypes.string.isRequired,
-      title: PropTypes.string.isRequired,
-      value: PropTypes.node.isRequired,
-      href: PropTypes.string,
-    }).isRequired
-  ),
-};
 
 export default SummaryList;

--- a/components/Summary/__snapshots__/SummaryList.spec.tsx.snap
+++ b/components/Summary/__snapshots__/SummaryList.spec.tsx.snap
@@ -61,7 +61,9 @@ exports[`SummaryList component should render properly 1`] = `
       <dd
         class="govuk-summary-list__value"
       >
-        <pre>
+        <pre
+          class="formattedTextArea"
+        >
           asd
 asd
 asd

--- a/components/Summary/__snapshots__/SummaryList.spec.tsx.snap
+++ b/components/Summary/__snapshots__/SummaryList.spec.tsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SummaryList component should render properly 1`] = `
+<DocumentFragment>
+  <dl
+    class="govuk-summary-list"
+  >
+    <div
+      class="govuk-summary-list__row"
+    >
+      <dt
+        class="govuk-summary-list__key"
+      >
+        Foo
+      </dt>
+      <dd
+        class="govuk-summary-list__value"
+      >
+        f_o_o
+      </dd>
+    </div>
+    <div
+      class="govuk-summary-list__row"
+    >
+      <dt
+        class="govuk-summary-list__key"
+      >
+        Bar
+      </dt>
+      <dd
+        class="govuk-summary-list__value"
+      >
+        <span>
+          f_o_o
+        </span>
+      </dd>
+      <dd
+        class="govuk-summary-list__actions"
+      >
+        <a
+          class="govuk-link"
+          href="#"
+        >
+          Change
+          <span
+            class="govuk-visually-hidden"
+          >
+             Bar
+          </span>
+        </a>
+      </dd>
+    </div>
+    <div
+      class="govuk-summary-list__row"
+    >
+      <dt
+        class="govuk-summary-list__key"
+      >
+        FooBar
+      </dt>
+      <dd
+        class="govuk-summary-list__value"
+      >
+        <pre>
+          asd
+asd
+asd
+
+        </pre>
+      </dd>
+    </div>
+  </dl>
+</DocumentFragment>
+`;

--- a/components/WarningNote/WarningNoteRecap/__snapshots__/WarningNoteRecap.spec.tsx.snap
+++ b/components/WarningNote/WarningNoteRecap/__snapshots__/WarningNoteRecap.spec.tsx.snap
@@ -119,7 +119,9 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          lorem ipsum
+          <pre>
+            lorem ipsum
+          </pre>
         </dd>
       </div>
       <div
@@ -133,7 +135,9 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          lorem ipsum
+          <pre>
+            lorem ipsum
+          </pre>
         </dd>
       </div>
       <div
@@ -147,7 +151,9 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          i am a note
+          <pre>
+            i am a note
+          </pre>
         </dd>
       </div>
       <div

--- a/components/WarningNote/WarningNoteRecap/__snapshots__/WarningNoteRecap.spec.tsx.snap
+++ b/components/WarningNote/WarningNoteRecap/__snapshots__/WarningNoteRecap.spec.tsx.snap
@@ -119,7 +119,9 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          <pre>
+          <pre
+            class="formattedTextArea"
+          >
             lorem ipsum
           </pre>
         </dd>
@@ -135,7 +137,9 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          <pre>
+          <pre
+            class="formattedTextArea"
+          >
             lorem ipsum
           </pre>
         </dd>
@@ -151,7 +155,9 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          <pre>
+          <pre
+            class="formattedTextArea"
+          >
             i am a note
           </pre>
         </dd>

--- a/utils/__snapshots__/summary.spec.jsx.snap
+++ b/utils/__snapshots__/summary.spec.jsx.snap
@@ -61,6 +61,7 @@ exports[`Summary utils formatData should format "ObjectInput" properly 1`] = `
 Object {
   "key": "oo",
   "title": "I am object component",
+  "type": "ObjectInput",
   "value": Array [
     <div>
       <span>
@@ -88,6 +89,7 @@ exports[`Summary utils formatData should format "ObjectInput" properly 2`] = `
 Object {
   "key": "oi",
   "title": "I am object component inline",
+  "type": "ObjectInput",
   "value": Array [
     <span>
       first
@@ -109,6 +111,7 @@ exports[`Summary utils formatData should format "TextInput isMulti" properly 1`]
 Object {
   "key": "text",
   "title": "Some_text",
+  "type": "TextInput",
   "value": <React.Fragment>
     <div>
       i

--- a/utils/summary.jsx
+++ b/utils/summary.jsx
@@ -90,6 +90,7 @@ export const formatData = (componentProps, formData) => {
   return {
     key: name,
     title: label,
+    type: component,
     value: Array.isArray(formData[name])
       ? isMulti
         ? formatIsMulti(formData[name], componentProps)


### PR DESCRIPTION
**What**  
- the `TextArea` value is not being wrapped by a `<pre>` element, so it maintains the formatting

<img width="495" alt="Screenshot 2021-03-17 at 09 05 07" src="https://user-images.githubusercontent.com/435399/111446282-86736980-870c-11eb-819c-a00d50a04443.png">

**How to test it**
- spin storybook
- check the summary component http://192.168.0.2:6006/?path=/story/summary--default