### PR TITLE
Added show more for long textAreas in Summary list

### DIFF
--- a/__mocks__/use-resize-observer.ts
+++ b/__mocks__/use-resize-observer.ts
@@ -1,0 +1,7 @@
+import { createRef, RefObject } from 'react';
+
+const useResizeObserverMocked = (): { ref: RefObject<HTMLDivElement> } => {
+  return { ref: createRef<HTMLDivElement>() };
+};
+
+export default useResizeObserverMocked;

--- a/components/Cases/CaseRecap/__snapshots__/CaseRecap.spec.jsx.snap
+++ b/components/Cases/CaseRecap/__snapshots__/CaseRecap.spec.jsx.snap
@@ -77,11 +77,20 @@ exports[`CaseRecap should update the queryString on search and run a new search 
         <dd
           class="govuk-summary-list__value"
         >
-          <pre
-            class="formattedTextArea"
-          >
-            Foo bar
-          </pre>
+          <div>
+            <div
+              class="container"
+              style="max-height: 95px;"
+            >
+              <div>
+                <pre
+                  class="formattedTextArea"
+                >
+                  Foo bar
+                </pre>
+              </div>
+            </div>
+          </div>
         </dd>
       </div>
     </dl>

--- a/components/ShowMoreBox/ShowMoreBox.module.scss
+++ b/components/ShowMoreBox/ShowMoreBox.module.scss
@@ -1,0 +1,11 @@
+.container {
+  transition: ease 100ms;
+  overflow: hidden;
+  & > div {
+    overflow: auto;
+  }
+}
+
+.trigger {
+  text-align: left;
+}

--- a/components/ShowMoreBox/ShowMoreBox.spec.tsx
+++ b/components/ShowMoreBox/ShowMoreBox.spec.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+
+import ShowMoreBox from './ShowMoreBox';
+
+let mockedElementHeight = 0;
+
+jest.mock(
+  'use-resize-observer',
+  () => ({ onResize }: { onResize: (arg: { height: number }) => void }) => {
+    onResize({ height: mockedElementHeight });
+    return {};
+  }
+);
+
+describe('ShowMoreBox component', () => {
+  mockedElementHeight = 1000;
+  it('should render properly - with show more', () => {
+    const { asFragment } = render(
+      <ShowMoreBox>
+        <pre>{'foo'}</pre>
+      </ShowMoreBox>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render properly - without', () => {
+    mockedElementHeight = 10;
+    const { asFragment } = render(
+      <ShowMoreBox>
+        <pre>{'foo'}</pre>
+      </ShowMoreBox>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/ShowMoreBox/ShowMoreBox.tsx
+++ b/components/ShowMoreBox/ShowMoreBox.tsx
@@ -1,0 +1,48 @@
+import { useState, useMemo } from 'react';
+import cx from 'classnames';
+import useResizeObserver from 'use-resize-observer';
+import debounce from 'lodash.debounce';
+
+import styles from './ShowMoreBox.module.scss';
+
+const useDebouncedResizeObserver = (wait = 500) => {
+  const [size, setSize] = useState<{ width?: number; height?: number }>({});
+  const onResize = useMemo(() => debounce(setSize, wait, { leading: true }), [
+    wait,
+  ]);
+  const { ref } = useResizeObserver<HTMLDivElement>({ onResize });
+
+  return { ref, ...size };
+};
+
+const ShowMoreBox = ({
+  children,
+  maxBoxWidth = 95,
+}: {
+  children: React.ReactElement;
+  maxBoxWidth?: number;
+}): React.ReactElement => {
+  const [expanded, setExpanded] = useState(false);
+  const { ref, height = 1 } = useDebouncedResizeObserver();
+  return (
+    <div>
+      <div
+        className={styles.container}
+        style={{ maxHeight: expanded ? height : maxBoxWidth }}
+      >
+        <div ref={ref}>{children}</div>
+      </div>
+      {height > 200 && (
+        <div
+          className={cx('govuk-link', styles.trigger)}
+          onClick={() => setExpanded(!expanded)}
+          role="button"
+        >
+          Show {expanded ? 'less' : 'more'}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ShowMoreBox;

--- a/components/ShowMoreBox/__snapshots__/ShowMoreBox.spec.tsx.snap
+++ b/components/ShowMoreBox/__snapshots__/ShowMoreBox.spec.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ShowMoreBox component should render properly - with show more 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="container"
+      style="max-height: 95px;"
+    >
+      <div>
+        <pre>
+          foo
+        </pre>
+      </div>
+    </div>
+    <div
+      class="govuk-link trigger"
+      role="button"
+    >
+      Show more
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ShowMoreBox component should render properly - without 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="container"
+      style="max-height: 95px;"
+    >
+      <div>
+        <pre>
+          foo
+        </pre>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/components/Summary/Summary.stories.jsx
+++ b/components/Summary/Summary.stories.jsx
@@ -15,7 +15,9 @@ Default.args = {
     asd: '',
     qwe: 'yo',
     foobar: 'asd',
-    textarea: 'asd\nasd\nasd\n',
+    textarea_verbose:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    textarea_succinct: 'asd\nasd',
   },
   formPath: '/form/foo/',
   formSteps: [
@@ -45,8 +47,13 @@ Default.args = {
       components: [
         {
           component: 'TextArea',
-          label: 'I am a long text',
-          name: 'textarea',
+          label: 'I am a verbose textarea',
+          name: 'textarea_verbose',
+        },
+        {
+          component: 'TextArea',
+          label: 'I am a succinct textarea',
+          name: 'textarea_succinct',
         },
       ],
     },

--- a/components/Summary/SummaryList.tsx
+++ b/components/Summary/SummaryList.tsx
@@ -1,3 +1,5 @@
+import ShowMoreBox from 'components/ShowMoreBox/ShowMoreBox';
+
 import styles from './Summary.module.scss';
 
 interface SummaryElement {
@@ -20,7 +22,9 @@ const SummaryList = ({ list }: Props): React.ReactElement => (
           <dt className="govuk-summary-list__key">{title}</dt>
           <dd className="govuk-summary-list__value">
             {type === 'TextArea' ? (
-              <pre className={styles.formattedTextArea}>{value}</pre>
+              <ShowMoreBox>
+                <pre className={styles.formattedTextArea}>{value}</pre>
+              </ShowMoreBox>
             ) : (
               value
             )}

--- a/components/Summary/__snapshots__/SummaryList.spec.tsx.snap
+++ b/components/Summary/__snapshots__/SummaryList.spec.tsx.snap
@@ -61,14 +61,23 @@ exports[`SummaryList component should render properly 1`] = `
       <dd
         class="govuk-summary-list__value"
       >
-        <pre
-          class="formattedTextArea"
-        >
-          asd
+        <div>
+          <div
+            class="container"
+            style="max-height: 95px;"
+          >
+            <div>
+              <pre
+                class="formattedTextArea"
+              >
+                asd
 asd
 asd
 
-        </pre>
+              </pre>
+            </div>
+          </div>
+        </div>
       </dd>
     </div>
   </dl>

--- a/components/WarningNote/WarningNoteRecap/__snapshots__/WarningNoteRecap.spec.tsx.snap
+++ b/components/WarningNote/WarningNoteRecap/__snapshots__/WarningNoteRecap.spec.tsx.snap
@@ -119,11 +119,20 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          <pre
-            class="formattedTextArea"
-          >
-            lorem ipsum
-          </pre>
+          <div>
+            <div
+              class="container"
+              style="max-height: 95px;"
+            >
+              <div>
+                <pre
+                  class="formattedTextArea"
+                >
+                  lorem ipsum
+                </pre>
+              </div>
+            </div>
+          </div>
         </dd>
       </div>
       <div
@@ -137,11 +146,20 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          <pre
-            class="formattedTextArea"
-          >
-            lorem ipsum
-          </pre>
+          <div>
+            <div
+              class="container"
+              style="max-height: 95px;"
+            >
+              <div>
+                <pre
+                  class="formattedTextArea"
+                >
+                  lorem ipsum
+                </pre>
+              </div>
+            </div>
+          </div>
         </dd>
       </div>
       <div
@@ -155,11 +173,20 @@ exports[`WarningNoteRecap should render correctly 1`] = `
         <dd
           class="govuk-summary-list__value"
         >
-          <pre
-            class="formattedTextArea"
-          >
-            i am a note
-          </pre>
+          <div>
+            <div
+              class="container"
+              style="max-height: 95px;"
+            >
+              <div>
+                <pre
+                  class="formattedTextArea"
+                >
+                  i am a note
+                </pre>
+              </div>
+            </div>
+          </div>
         </dd>
       </div>
       <div

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "@types/lodash.debounce": "^4.0.6",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
     "cookie": "^0.4.1",
@@ -29,6 +30,7 @@
     "govuk-frontend": "^3.10.2",
     "http-status-codes": "^2.1.4",
     "jsonwebtoken": "^8.5.1",
+    "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",
     "next": "10.0.5",
     "react": "17.0.1",
@@ -41,6 +43,7 @@
     "serverless-http": "^2.6.0",
     "swr": "^0.4.1",
     "uk-postcode-validator": "^1.1.1",
+    "use-resize-observer": "^7.0.0",
     "yup": "^0.32.8"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash.debounce@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz#c5a2326cd3efc46566c47e4c0aa248dc0ee57d60"
+  integrity sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/lodash@^4.14.165":
   version "4.14.167"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.167.tgz#ce7d78553e3c886d4ea643c37ec7edc20f16765e"
@@ -9392,6 +9404,11 @@ lodash.clonedeep@^2.0.0:
     lodash._baseclone "~2.4.1"
     lodash._basecreatecallback "~2.4.1"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.foreach@~2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-2.4.1.tgz#fe3fc3a34c86c94cab6f9522560282741e016309"
@@ -11987,6 +12004,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -13809,6 +13831,13 @@ use-latest@^1.0.0, use-latest@^1.2.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-resize-observer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-7.0.0.tgz#15f0efbd5a4e08a8cc51901f21a89ba836f2116e"
+  integrity sha512-+RjrQsk/mL8aKy4TGBDiPkUv6whyeoGDMIZYk0gOGHOlnrsjImC+jG6lfAFcBCKAG9epGRL419adhDNdkDCQkA==
+  dependencies:
+    resize-observer-polyfill "^1.5.1"
 
 use-subscription@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
**What**  
Added "show more" for textAreas longer than 3 lines.
The check of the element height is done using `ResizeObserver`

<img width="813" alt="Screenshot 2021-03-17 at 15 42 45" src="https://user-images.githubusercontent.com/435399/111497132-2814ae00-8741-11eb-9730-cb3d0da08220.png">


**How to test it**
- spin up storybook
- check http://192.168.0.2:6006/?path=/story/summary--default
- check that everything looks good