### PR TITLE
Review warning note form

### DIFF
--- a/components/Steps/ReviewWarningNoteConfirmation.spec.tsx
+++ b/components/Steps/ReviewWarningNoteConfirmation.spec.tsx
@@ -1,0 +1,52 @@
+import { render } from '@testing-library/react';
+import ReviewWarningNoteConfirmation from './ReviewWarningNoteConfirmation';
+
+describe('Review Warning Note Confirmation', () => {
+  const props = {
+    formData: {
+      person: {
+        dateOfBirth: '2020-11-13',
+        firstName: 'Ciasom',
+        lastName: 'Tesselate',
+        mosaicId: '44000000',
+        nhsNumber: '12345',
+        ageContext: 'A',
+        gender: 'F',
+      },
+      reviewDecision: 'Yes',
+    },
+  };
+
+  it('should render the correct text if the review decision was yes', () => {
+    const { asFragment, getByText } = render(
+      <ReviewWarningNoteConfirmation {...props} />
+    );
+    expect(
+      getByText('The Warning Note has been renewed for Ciasom Tesselate')
+    ).toBeInTheDocument();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('it should rennder the correct text if the decision was no', () => {
+    const props = {
+      formData: {
+        person: {
+          dateOfBirth: '2020-11-13',
+          firstName: 'Ciasom',
+          lastName: 'Tesselate',
+          mosaicId: '44000000',
+          nhsNumber: '12345',
+          ageContext: 'A',
+          gender: 'F',
+        },
+        reviewDecision: 'No',
+      },
+    };
+
+    const { asFragment, getByText } = render(
+      <ReviewWarningNoteConfirmation {...props} />
+    );
+    expect(getByText('This Warning Note has been closed')).toBeInTheDocument();
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/Steps/ReviewWarningNoteConfirmation.tsx
+++ b/components/Steps/ReviewWarningNoteConfirmation.tsx
@@ -1,0 +1,37 @@
+import { Resident } from 'types';
+import Button from 'components/Button/Button';
+
+export interface Props {
+  formData: {
+    person: Resident;
+    reviewDecision: string;
+    [key: string]: unknown;
+  };
+}
+
+const ReviewWarningNoteConfirmation = ({
+  formData,
+}: Props): React.ReactElement => {
+  return (
+    <>
+      <div className="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-9">
+        <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
+          {formData.reviewDecision === 'Yes'
+            ? `The Warning Note has been renewed for ${formData.person.firstName} ${formData.person.lastName}`
+            : 'This Warning Note has been closed'}
+        </h1>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Button label="Return to search" isSecondary wideButton route={'/'} />
+        <Button
+          label="View person"
+          wideButton
+          route={`/people/${formData.person.mosaicId}`}
+        />
+      </div>
+    </>
+  );
+};
+
+export default ReviewWarningNoteConfirmation;

--- a/components/Steps/__snapshots__/ReviewWarningNoteConfirmation.spec.tsx.snap
+++ b/components/Steps/__snapshots__/ReviewWarningNoteConfirmation.spec.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Review Warning Note Confirmation it should rennder the correct text if the decision was no 1`] = `
+<DocumentFragment>
+  <div
+    class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-9"
+  >
+    <h1
+      class="govuk-fieldset__legend--l gov-weight-lighter"
+    >
+      This Warning Note has been closed
+    </h1>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Review Warning Note Confirmation should render the correct text if the review decision was yes 1`] = `
+<DocumentFragment>
+  <div
+    class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-9"
+  >
+    <h1
+      class="govuk-fieldset__legend--l gov-weight-lighter"
+    >
+      The Warning Note has been renewed for Ciasom Tesselate
+    </h1>
+  </div>
+</DocumentFragment>
+`;

--- a/components/Steps/__snapshots__/ReviewWarningNoteConfirmation.spec.tsx.snap
+++ b/components/Steps/__snapshots__/ReviewWarningNoteConfirmation.spec.tsx.snap
@@ -11,6 +11,24 @@ exports[`Review Warning Note Confirmation it should rennder the correct text if 
       This Warning Note has been closed
     </h1>
   </div>
+  <div
+    style="display: flex; justify-content: space-between;"
+  >
+    <button
+      class="govuk-button govuk-button--secondary"
+      data-module="govuk-button"
+      style="min-width: 200px;"
+    >
+      Return to search
+    </button>
+    <button
+      class="govuk-button"
+      data-module="govuk-button"
+      style="min-width: 200px;"
+    >
+      View person
+    </button>
+  </div>
 </DocumentFragment>
 `;
 
@@ -24,6 +42,24 @@ exports[`Review Warning Note Confirmation should render the correct text if the 
     >
       The Warning Note has been renewed for Ciasom Tesselate
     </h1>
+  </div>
+  <div
+    style="display: flex; justify-content: space-between;"
+  >
+    <button
+      class="govuk-button govuk-button--secondary"
+      data-module="govuk-button"
+      style="min-width: 200px;"
+    >
+      Return to search
+    </button>
+    <button
+      class="govuk-button"
+      data-module="govuk-button"
+      style="min-width: 200px;"
+    >
+      View person
+    </button>
   </div>
 </DocumentFragment>
 `;

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -16,6 +16,7 @@ const formSteps: FormStep[] = [
         name: 'reviewDiscussion',
         label: 'Have you discussed this review with the individual',
         isRadiosInline: true,
+        rules: { required: true },
         conditionalRender: ({ person }) => person.ageContext === 'A',
       },
       {
@@ -47,6 +48,7 @@ const formSteps: FormStep[] = [
         component: 'Radios',
         name: 'reviewDecision',
         label: 'What do you want to do?',
+        rules: { required: true },
         options: [
           { value: 'Yes', text: 'Renew Warning Note' },
           { value: 'No', text: 'End Warning Note' },
@@ -56,6 +58,7 @@ const formSteps: FormStep[] = [
         component: 'DateInput',
         name: 'nextReviewDate',
         label: 'Next review date',
+        rules: { required: true },
         hint:
           'Next review date cannot be more than 1 year from date review undertaken ',
         conditionalRender: ({ reviewDecision }) => reviewDecision === 'Yes',

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -1,0 +1,64 @@
+import { FormStep } from 'components/Form/types';
+
+const formSteps: FormStep[] = [
+  {
+    id: 'review-warning-note',
+    title: 'Warning Note Review',
+    components: [
+      {
+        component: 'DateInput',
+        name: 'reviewDate',
+        label: 'Date review undertaken',
+        rules: { required: true },
+      },
+      {
+        component: 'Radios',
+        name: 'reviewDiscussion',
+        label: 'Have you discussed this review with the individual',
+        isRadiosInline: true,
+        conditionalRender: ({ person }) => person.ageContext === 'A',
+      },
+      {
+        component: 'TextArea',
+        name: 'reviewDetails',
+        label: 'Details of review',
+        hint:
+          'include details of disclosure to individual, any updates and why renewing or ending',
+        rules: { required: true },
+      },
+      <h2 key="manager review discussion">Review discussed with manager</h2>,
+      <span className="govuk-caption-l">
+        This Warning Note review has been discussed and agreed by the manager
+        named below
+      </span>,
+      {
+        component: 'TextInput',
+        name: 'discussedWithManager',
+        label: 'Manager’s name',
+        rules: { required: true },
+      },
+      {
+        component: 'DateInput',
+        name: 'discussedWithManagerDate',
+        label: 'Date discussed with manager',
+        rules: { required: true },
+      },
+      {
+        component: 'Radios',
+        name: 'reviewDecision',
+        label: 'What do you want to do?',
+        isRadiosInline: true,
+      },
+      {
+        component: 'DateInput',
+        name: 'nextReviewDate',
+        label: 'Next review date',
+        hint:
+          'Next review date cannot be more than 1 year from date review undertaken ',
+        conditionalRender: ({ reviewDecision }) => reviewDecision === 'Yes',
+      },
+    ],
+  },
+];
+
+export default formSteps;

--- a/data/forms/warning-note-review.tsx
+++ b/data/forms/warning-note-review.tsx
@@ -3,7 +3,7 @@ import { FormStep } from 'components/Form/types';
 const formSteps: FormStep[] = [
   {
     id: 'review-warning-note',
-    title: 'Warning Note Review',
+    title: 'Warning Review Details',
     components: [
       {
         component: 'DateInput',
@@ -27,7 +27,7 @@ const formSteps: FormStep[] = [
         rules: { required: true },
       },
       <h2 key="manager review discussion">Review discussed with manager</h2>,
-      <span className="govuk-caption-l">
+      <span key="manager review caption" className="govuk-caption-l">
         This Warning Note review has been discussed and agreed by the manager
         named below
       </span>,
@@ -47,7 +47,10 @@ const formSteps: FormStep[] = [
         component: 'Radios',
         name: 'reviewDecision',
         label: 'What do you want to do?',
-        isRadiosInline: true,
+        options: [
+          { value: 'Yes', text: 'Renew Warning Note' },
+          { value: 'No', text: 'End Warning Note' },
+        ],
       },
       {
         component: 'DateInput',

--- a/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
@@ -8,11 +8,14 @@ import { Resident, User } from 'types';
 import FormWizard from 'components/FormWizard/FormWizard';
 import formSteps from 'data/forms/warning-note-review';
 import { useAuth } from 'components/UserContext/UserContext';
+import CustomConfirmation from 'components/Steps/ReviewWarningNoteConfirmation';
 
 const ReviewWarningNote = (): React.ReactElement => {
-  const { query } = useRouter();
+  const { query, asPath } = useRouter();
   const personId = Number(query.id as string);
   const warningNoteId = Number(query.warningNoteId as string);
+  const summary = asPath.includes('summary');
+  const confirmation = asPath.includes('confirmation');
   const { user } = useAuth() as { user: User };
   const onFormSubmit = useCallback(
     (person: Resident) => async ({
@@ -39,14 +42,33 @@ const ReviewWarningNote = (): React.ReactElement => {
     <>
       <BackButton />
       <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
-        Renew/end Warning Note
+        {summary
+          ? 'Check Warning Note renew details'
+          : confirmation
+          ? 'Warning Note renew confirmed'
+          : 'Review/end Warning Note'}
       </h1>
       <PersonView personId={personId} expandView>
         {(person: Resident) => (
           <>
-            <div className="govuk-!-margin-top-7">
-              <WarningNoteRecap person={person} warningNoteId={warningNoteId} />
-            </div>
+            {!summary && !confirmation && (
+              <>
+                <h2>Reviewing or ending a Warning Note</h2>
+                <span className="govuk-caption-l">
+                  Warnings must be kept under review by Team Managers and the
+                  evidence to support continued use must be reviewed at least
+                  annually. Warnings must always be reviewed on the closure or
+                  transfer of the case
+                </span>
+                <div className="govuk-!-margin-top-7">
+                  <WarningNoteRecap
+                    person={person}
+                    warningNoteId={warningNoteId}
+                  />
+                </div>
+                <h2>Warning Note review</h2>
+              </>
+            )}
             <FormWizard
               formPath={`/people/${personId}/warning-notes/${warningNoteId}/`}
               formSteps={formSteps}
@@ -54,6 +76,8 @@ const ReviewWarningNote = (): React.ReactElement => {
               onFormSubmit={onFormSubmit(person)}
               personDetails={{ ...person }}
               defaultValues={{ person }}
+              customConfirmation={CustomConfirmation}
+              hideBackButton
             ></FormWizard>
           </>
         )}

--- a/pages/people/[id]/warning-notes/[warningNoteId]/index.tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/index.tsx
@@ -1,14 +1,40 @@
 import { useRouter } from 'next/router';
+import { useCallback } from 'react';
 
 import PersonView from 'components/PersonView/PersonView';
 import BackButton from 'components/Layout/BackButton/BackButton';
 import WarningNoteRecap from 'components/WarningNote/WarningNoteRecap/WarningNoteRecap';
-import { Resident } from 'types';
+import { Resident, User } from 'types';
+import FormWizard from 'components/FormWizard/FormWizard';
+import formSteps from 'data/forms/warning-note-review';
+import { useAuth } from 'components/UserContext/UserContext';
 
 const ReviewWarningNote = (): React.ReactElement => {
   const { query } = useRouter();
   const personId = Number(query.id as string);
   const warningNoteId = Number(query.warningNoteId as string);
+  const { user } = useAuth() as { user: User };
+  const onFormSubmit = useCallback(
+    (person: Resident) => async ({
+      form_name,
+      ...formData
+    }: Record<string, unknown>) => {
+      console.log({
+        personId: parseInt(person.mosaicId, 10), // TODO: needs to be fixed BE
+        firstName: person.firstName,
+        lastName: person.lastName,
+        contextFlag: person.ageContext,
+        dateOfBirth: person.dateOfBirth,
+        workerEmail: user.email,
+        formNameOverall:
+          person.ageContext === 'A' ? 'ASC_case_note' : 'CFS_case_note',
+        formName: form_name,
+        caseFormData: JSON.stringify(formData),
+      });
+    },
+    [user.email]
+  );
+
   return (
     <>
       <BackButton />
@@ -17,9 +43,19 @@ const ReviewWarningNote = (): React.ReactElement => {
       </h1>
       <PersonView personId={personId} expandView>
         {(person: Resident) => (
-          <div className="govuk-!-margin-top-7">
-            <WarningNoteRecap person={person} warningNoteId={warningNoteId} />
-          </div>
+          <>
+            <div className="govuk-!-margin-top-7">
+              <WarningNoteRecap person={person} warningNoteId={warningNoteId} />
+            </div>
+            <FormWizard
+              formPath={`/people/${personId}/warning-notes/${warningNoteId}/`}
+              formSteps={formSteps}
+              title="Review Warning Note"
+              onFormSubmit={onFormSubmit(person)}
+              personDetails={{ ...person }}
+              defaultValues={{ person }}
+            ></FormWizard>
+          </>
         )}
       </PersonView>
     </>


### PR DESCRIPTION
**What**  
Add the review form to the warning note review/end page, add custom confirmation component to display the correct messages once a warning note has been reviewed or ended

**Why**  
This form allows users to review a warning note and update its details or if need be end the warning note

**Anything else?**
The backend implementation is still not implemented as such this PR is only for getting the form ready once the backend  is ready.
![image](https://user-images.githubusercontent.com/43789512/111663237-83f63a00-8808-11eb-83c6-05baac4d168e.png)
