### PR TITLE
HOTFIX: Fix wrong types for warning note review

### DIFF
--- a/components/Steps/ReviewWarningNoteConfirmation.spec.tsx
+++ b/components/Steps/ReviewWarningNoteConfirmation.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { AgeContext } from 'types';
 import ReviewWarningNoteConfirmation from './ReviewWarningNoteConfirmation';
 
 describe('Review Warning Note Confirmation', () => {
@@ -8,9 +9,9 @@ describe('Review Warning Note Confirmation', () => {
         dateOfBirth: '2020-11-13',
         firstName: 'Ciasom',
         lastName: 'Tesselate',
-        mosaicId: '44000000',
+        mosaicId: 44000000,
         nhsNumber: '12345',
-        ageContext: 'A',
+        ageContext: 'A' as AgeContext,
         gender: 'F',
       },
       reviewDecision: 'Yes',
@@ -34,9 +35,9 @@ describe('Review Warning Note Confirmation', () => {
           dateOfBirth: '2020-11-13',
           firstName: 'Ciasom',
           lastName: 'Tesselate',
-          mosaicId: '44000000',
+          mosaicId: 44000000,
           nhsNumber: '12345',
-          ageContext: 'A',
+          ageContext: 'A' as AgeContext,
           gender: 'F',
         },
         reviewDecision: 'No',

--- a/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
+++ b/pages/people/[id]/warning-notes/[warningNoteId]/[[...stepId]].tsx
@@ -23,7 +23,7 @@ const ReviewWarningNote = (): React.ReactElement => {
       ...formData
     }: Record<string, unknown>) => {
       console.log({
-        personId: parseInt(person.mosaicId, 10), // TODO: needs to be fixed BE
+        personId: person.mosaicId, // TODO: needs to be fixed BE
         firstName: person.firstName,
         lastName: person.lastName,
         contextFlag: person.ageContext,


### PR DESCRIPTION
**What**  
Certain pieces of data being passed to the ReviewWarningNoteConfirmation component were of the wrong type, this PR fixes this issue

**Why**  
To fix the merged warning note review page PR within master