### PR TITLE
fix date input when month is a negative value

### DIFF
--- a/components/Form/DateInput/DateInput.tsx
+++ b/components/Form/DateInput/DateInput.tsx
@@ -85,9 +85,12 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
                   pattern="^\d{2}$"
                   inputMode="numeric"
                   defaultValue={date.day}
-                  onChange={({ target: { value } }) =>
-                    setNewDate({ day: value })
-                  }
+                  onChange={({
+                    target: {
+                      value,
+                      validity: { valid },
+                    },
+                  }) => valid && setNewDate({ day: value })}
                   ref={ref}
                   {...otherProps}
                 />
@@ -113,9 +116,12 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
                   pattern="^\d{2}$"
                   inputMode="numeric"
                   defaultValue={date.month}
-                  onChange={({ target: { value } }) =>
-                    setNewDate({ month: value })
-                  }
+                  onChange={({
+                    target: {
+                      value,
+                      validity: { valid },
+                    },
+                  }) => valid && setNewDate({ month: value })}
                   {...otherProps}
                 />
               </div>
@@ -140,9 +146,12 @@ const DateInput = forwardRef<HTMLInputElement, InputProps>(
                   pattern="^\d{4}$"
                   inputMode="numeric"
                   defaultValue={date.year}
-                  onChange={({ target: { value } }) =>
-                    setNewDate({ year: value })
-                  }
+                  onChange={({
+                    target: {
+                      value,
+                      validity: { valid },
+                    },
+                  }) => valid && setNewDate({ year: value })}
                   {...otherProps}
                 />
               </div>


### PR DESCRIPTION
**What**  
Trigger date input `onchange` only if the input is valid

The problem was that the component is returning the date as string `yyyy-mm-dd` if month was `-1` it was like `yyyy--1` and because of that was setting the day as `1` that is invalid as it should be 2 digits and the error was there until you changed the day input.

**Steps to reproduce the bug**
- go https://social-care-service-staging.hackney.gov.uk/people/234/warning-notes/add
- enter `12 12 2000` as first date
- press enter to submit the uncompleted form
- change the month to `-`1
- press enter
- change the month to `12`
- the error is still there

<img width="290" alt="Screenshot 2021-03-22 at 12 04 49" src="https://user-images.githubusercontent.com/435399/112042593-f9834280-8b47-11eb-817c-88ff7c49d73e.png">

