### PR TITLE
Update new person

### DIFF
--- a/components/FormWizard/FormWizard.jsx
+++ b/components/FormWizard/FormWizard.jsx
@@ -14,6 +14,7 @@ import { getFormData, saveData } from 'utils/saveData';
 const FormWizard = ({
   formPath,
   formSteps,
+  stepHeader,
   successMessage,
   onFormSubmit,
   defaultValues = {},
@@ -81,6 +82,7 @@ const FormWizard = ({
               </legend>
             </>
           )}
+        {stepHeader?.()}
         <StepComponent
           {...step}
           key={stepId?.join('-')}
@@ -155,6 +157,7 @@ FormWizard.propTypes = {
   customConfirmation: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   customSummary: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   personDetails: PropTypes.object,
+  stepHeader: PropTypes.func,
 };
 
 export default FormWizard;

--- a/components/PersonView/PersonView.tsx
+++ b/components/PersonView/PersonView.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
 import Spinner from 'components/Spinner/Spinner';
 import PersonDetails from './PersonDetails';
@@ -9,6 +11,7 @@ interface Props {
   children?: React.ReactChild | ((arg0: Resident) => React.ReactChild);
   expandView?: boolean;
   showPersonDetails?: boolean;
+  canEdit?: boolean;
 }
 
 const PersonView = ({
@@ -16,6 +19,7 @@ const PersonView = ({
   expandView,
   children,
   showPersonDetails = true,
+  canEdit,
 }: Props): React.ReactElement => {
   const { data: person, error } = useResident(personId);
   if (error) {
@@ -27,9 +31,16 @@ const PersonView = ({
   return (
     <>
       {!expandView && (
-        <h1 className="govuk-fieldset__legend--l gov-weight-lighter govuk-expand-title">
-          {person.firstName} {person.lastName}
-        </h1>
+        <div className="lbh-table-header">
+          <h1 className="govuk-fieldset__legend--l gov-weight-lighter govuk-expand-title">
+            {person.firstName} {person.lastName}
+          </h1>
+          {canEdit && (
+            <Link href={`/people/${person.mosaicId}/update`}>
+              <a className="govuk-link">Update person</a>
+            </Link>
+          )}
+        </div>
       )}
       {showPersonDetails && (
         <PersonDetails person={person} expandView={expandView} />

--- a/data/forms/create-new-person.tsx
+++ b/data/forms/create-new-person.tsx
@@ -16,15 +16,6 @@ const formConfig: FormConfig = {
       id: 'client-details',
       title: 'Person Details',
       components: [
-        <h1
-          key="form-title"
-          className="govuk-fieldset__legend--xl gov-weight-lighter"
-        >
-          Add a new person
-        </h1>,
-        <p key="subtitle" className="govuk-body">
-          Use this form to add a new referral
-        </p>,
         <h3
           key="subtitle-details"
           className="govuk-fieldset__legend--l gov-weight-lighter govuk-!-margin-bottom-5"

--- a/pages/people/[id]/index.tsx
+++ b/pages/people/[id]/index.tsx
@@ -8,15 +8,22 @@ import Cases from 'components/Cases/Cases';
 import AllocatedWorkers from 'components/AllocatedWorkers/AllocatedWorkers';
 import WarningNotes from 'components/WarningNote/WarningNotes';
 import Stack from 'components/Stack/Stack';
+import { useAuth } from 'components/UserContext/UserContext';
+import { User } from 'types';
 
 const PersonPage = (): React.ReactElement => {
   const { query } = useRouter();
+  const { user } = useAuth() as { user: User };
   const personId = Number(query.id as string);
   return (
     <>
       <Seo title={`Person Details - #${query.id}`} />
       <BackButton />
-      <PersonView personId={personId} showPersonDetails={false}>
+      <PersonView
+        personId={personId}
+        showPersonDetails={false}
+        canEdit={user.hasAdminPermissions}
+      >
         {(person) => (
           <Stack space={7} className="govuk-!-margin-top-7">
             <WarningNotes id={personId} />

--- a/pages/people/[id]/update/[[...stepId]].tsx
+++ b/pages/people/[id]/update/[[...stepId]].tsx
@@ -1,0 +1,70 @@
+import { useState, ReactElement } from 'react';
+import { useRouter } from 'next/router';
+
+import { useAuth } from 'components/UserContext/UserContext';
+import FormWizard from 'components/FormWizard/FormWizard';
+import { updateResident } from 'utils/api/residents';
+import CustomConfirmation from 'components/Steps/PersonConfirmation';
+import { useResident } from 'utils/api/residents';
+import Spinner from 'components/Spinner/Spinner';
+import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
+
+import form from 'data/forms/create-new-person';
+
+import type { User } from 'types';
+
+const StepHeader = () => (
+  <>
+    <h1
+      key="form-title"
+      className="govuk-fieldset__legend--xl gov-weight-lighter"
+    >
+      Update person details
+    </h1>
+  </>
+);
+
+interface FormData {
+  contextFlag: 'A' | 'C';
+  nhsNumber: string;
+  [key: string]: unknown;
+}
+
+const UpdatePerson = (): ReactElement => {
+  const { query } = useRouter();
+  const [personId] = useState(Number(query.id));
+  const { data: person, error } = useResident(personId);
+  const { user } = useAuth() as { user: User };
+  const onFormSubmit = async (formData: FormData) => {
+    const ref = await updateResident({
+      ...formData,
+      contextFlag: formData.contextFlag || user.permissionFlag,
+      nhsNumber: Number(formData.nhsNumber),
+      createdBy: user.email,
+    });
+    return ref;
+  };
+  if (error) {
+    return <ErrorMessage />;
+  }
+  if (!person) {
+    return <Spinner />;
+  }
+  return (
+    <FormWizard
+      formPath={`/people/${personId}/update/`}
+      formSteps={form.steps}
+      title={form.title}
+      defaultValues={{
+        user,
+        ...{ ...person, contextFlag: person.ageContext },
+      }}
+      onFormSubmit={onFormSubmit}
+      successMessage={form.successMessage}
+      customConfirmation={CustomConfirmation}
+      stepHeader={StepHeader}
+    />
+  );
+};
+
+export default UpdatePerson;

--- a/pages/people/add/[[...stepId]].tsx
+++ b/pages/people/add/[[...stepId]].tsx
@@ -7,6 +7,20 @@ import { User } from 'types';
 
 import form from 'data/forms/create-new-person';
 
+const StepHeader = () => (
+  <>
+    <h1
+      key="form-title"
+      className="govuk-fieldset__legend--xl gov-weight-lighter"
+    >
+      Add a new person
+    </h1>
+    <p key="subtitle" className="govuk-body">
+      Use this form to add a new referral
+    </p>
+  </>
+);
+
 interface FormData {
   nhsNumber: string;
   [key: string]: unknown;
@@ -18,7 +32,7 @@ const CreateNewPerson = (): React.ReactElement => {
     const ref = await addResident({
       ...formData,
       contextFlag: formData.contextFlag || user.permissionFlag,
-      nhsNumber: parseInt(formData.nhsNumber, 10),
+      nhsNumber: Number(formData.nhsNumber),
       createdBy: user.email,
     });
     return ref;
@@ -32,6 +46,7 @@ const CreateNewPerson = (): React.ReactElement => {
       defaultValues={{ user }}
       successMessage={form.successMessage}
       customConfirmation={CustomConfirmation}
+      stepHeader={StepHeader}
     />
   );
 };

--- a/stylesheets/all.scss
+++ b/stylesheets/all.scss
@@ -60,7 +60,7 @@ $screen-sm-min: 576px;
 .lbh-table-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: baseline;
   button {
     margin-bottom: 0.5rem;
   }

--- a/utils/api/residents.ts
+++ b/utils/api/residents.ts
@@ -29,3 +29,10 @@ export const addResident = async (
   const { data } = await axios.post(`/api/residents`, formData);
   return { ref: data?.personId, data };
 };
+
+export const updateResident = async (
+  formData: Record<string, unknown>
+): Promise<Record<string, unknown>> => {
+  const { data } = await axios.patch(`/api/residents`, formData);
+  return { ref: data?.personId, data };
+};


### PR DESCRIPTION
**What**  
- created `/people/:peopleId/update` page
- extended `PersonView` with `canEdit` flag
- made `stepHeader` configurable in the `FormWizard`
- the _update person_ is going to visible only for admins

**What is missing**
- the endpoint integration, waiting for the BE

**How to test it**
- go to person people view
- click "update person"
- check the form is autofilling (note: some mapping has to be done by the BE)